### PR TITLE
Issue15: Log to file

### DIFF
--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 import threading
 import time
+import os
 
 from logging.handlers import TimedRotatingFileHandler
 
@@ -197,7 +198,7 @@ def createLog(path):
     tempLogger.setLevel(logging.INFO)
 
     handler = TimedRotatingFileHandler(path,
-                                       when="h",
+                                       when="m",
                                        interval=1,
                                        backupCount=5)
     tempLogger.addHandler(handler)
@@ -212,8 +213,12 @@ def main():
     another to periodically send status packets to APRS-IS in order to keep
     the connection alive.
     """
+    # Create logger, must be global for functions and threads
     global logger
-    logger = createLog("log.txt")
+
+    # Log to sys.prefix + aprs2influxdb.log
+    log = os.path.join(sys.prefix, "aprs2influxdb.log")
+    logger = createLog(log)
 
     # Start login for APRS-IS
     logger.info("Logging into APRS-IS as {0} on port {1}".format(args.callsign, args.port))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -188,21 +188,30 @@ def heartbeat(conn, callsign, interval):
         time.sleep(float(interval) * 60)  # Sent every interval minutes
 
 
-def createLog(path):
+def createLog(path, debug=False):
     """Create a rotating log at the specified path and return logger
 
     keyword arguments:
     path -- path to log file
+    debug -- Boolean to set DEBUG log level,
     """
     tempLogger = logging.getLogger(__name__)
-    #tempLogger.setLevel(logging.INFO)
-    tempLogger.setLevel(logging.WARNING)
 
+    # Add handler for rotating file
     handler = TimedRotatingFileHandler(path,
                                        when="h",
                                        interval=1,
                                        backupCount=5)
     tempLogger.addHandler(handler)
+    # Add handler for stdout printing
+    screenHandler = logging.StreamHandler(sys.stdout)
+    tempLogger.addHandler(screenHandler)
+
+    # Set logging level
+    if debug:
+        tempLogger.setLevel(logging.DEBUG)
+    else:
+        tempLogger.setLevel(logging.WARNING)
 
     return tempLogger
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -24,6 +24,7 @@ parser.add_argument('--dbname', help='Set InfluxDB database name', default="mydb
 parser.add_argument('--callsign', help='Set APRS-IS login callsign', default="nocall")
 parser.add_argument('--port', help='Set APRS-IS port', default="10152")
 parser.add_argument('--interval', help='Set APRS-IS heartbeat interval in minutes', default="15")
+parser.add_argument('--debug', help='Set logging level to DEBUG', action="store_true")
 
 # Parse the arguments
 args = parser.parse_args()
@@ -101,7 +102,7 @@ def jsonToLineProtocol(jsonData):
 
         except KeyError as e:
             # Expect many KeyErrors for stations not sending telemetry
-            logger.debug(e)
+            pass
 
         try:
             comment = jsonData.get("comment").encode('ascii', 'ignore')
@@ -228,7 +229,7 @@ def main():
 
     # Log to sys.prefix + aprs2influxdb.log
     log = os.path.join(sys.prefix, "aprs2influxdb.log")
-    logger = createLog(log)
+    logger = createLog(log, args.debug)
 
     # Start login for APRS-IS
     logger.info("Logging into APRS-IS as {0} on port {1}".format(args.callsign, args.port))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -204,6 +204,7 @@ def createLog(path, debug=False):
                                        interval=1,
                                        backupCount=5)
     tempLogger.addHandler(handler)
+
     # Add handler for stdout printing
     screenHandler = logging.StreamHandler(sys.stdout)
     tempLogger.addHandler(screenHandler)
@@ -215,6 +216,7 @@ def createLog(path, debug=False):
         tempLogger.setLevel(logging.WARNING)
 
     return tempLogger
+
 
 def main():
     """Main function of aprs2influxdb

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -77,7 +77,6 @@ def jsonToLineProtocol(jsonData):
 
         except KeyError as e:
             logger.error(e)
-            logger.error(jsonData)
 
         tagStr = ",".join(tags)
 
@@ -89,7 +88,6 @@ def jsonToLineProtocol(jsonData):
             fields.append("speed={0}".format(jsonData.get("speed", 0)))
         except KeyError as e:
             logger.error(e)
-            logger.error(jsonData)
 
         try:
             if jsonData["telemetry"]["seq"]:
@@ -104,13 +102,11 @@ def jsonToLineProtocol(jsonData):
         except KeyError as e:
             # Expect many KeyErrors for stations not sending telemetry
             logger.debug(e)
-            logger.debug(jsonData)
 
         try:
             comment = jsonData.get("comment").encode('ascii', 'ignore')
 
             if comment:
-                logger.debug(comment)
                 fields.append("comment=\"{0}\"".format(comment.replace("\"", "")))
 
         except UnicodeError as e:
@@ -147,7 +143,6 @@ def callback(packet):
 
         except influxdb.exceptions.InfluxDBClientError as e:
             logger.error(e)
-            logger.error(packet)
 
 
 def connectInfluxDB():
@@ -194,11 +189,17 @@ def heartbeat(conn, callsign, interval):
 
 
 def createLog(path):
+    """Create a rotating log at the specified path and return logger
+
+    keyword arguments:
+    path -- path to log file
+    """
     tempLogger = logging.getLogger(__name__)
-    tempLogger.setLevel(logging.INFO)
+    #tempLogger.setLevel(logging.INFO)
+    tempLogger.setLevel(logging.WARNING)
 
     handler = TimedRotatingFileHandler(path,
-                                       when="m",
+                                       when="h",
                                        interval=1,
                                        backupCount=5)
     tempLogger.addHandler(handler)


### PR DESCRIPTION
Addresses #15 by adding the following changes:

- Log to file with a handler
- Log to stdout with a handler
- Log file rotates every hour and stores up to 5 hours of logs
- Logs are saved to `sys.prefix` location. This plays nice with virtualenv & cross platform
- Added `argparse` option for `--debug` flag to set logging to debug level both stdout and rotating filehandler.