### PR TITLE
Support Parsing of Almost All APRS-IS Packets & More!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python: "2.7"
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - py.test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # aprs2influxdb
+[![Build Status](https://travis-ci.org/FaradayRF/aprs2influxdb.svg?branch=master)](https://travis-ci.org/FaradayRF/aprs2influxdb)
 This program interfaces ham radio APRS-IS servers and saves packet data into an influxdb database. aprs2influxdb handles the connection, parsing, and saving of data into an influxdb database from APRS-IS using line protocol formatted strings. Periodically, a status message is also sent to the APRS-IS server in order to maintain the connection with the APRS-IS server by preventing a timeout.
 
 Supported APRS Packet Formats:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # aprs2influxdb
 [![Build Status](https://travis-ci.org/FaradayRF/aprs2influxdb.svg?branch=master)](https://travis-ci.org/FaradayRF/aprs2influxdb)
+
 This program interfaces ham radio APRS-IS servers and saves packet data into an influxdb database. aprs2influxdb handles the connection, parsing, and saving of data into an influxdb database from APRS-IS using line protocol formatted strings. Periodically, a status message is also sent to the APRS-IS server in order to maintain the connection with the APRS-IS server by preventing a timeout.
 
 Supported APRS Packet Formats:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,16 @@ This program interfaces ham radio APRS-IS servers and saves packet data into an 
 
 Supported APRS Packet Formats:
 * uncompressed
+* mic-e
+* object
+* compressed
+* status
+* wx
+* beacon
+* bulletin
+* message
 
-Non-ASCII characters in APRS packets are ignored!
+Non-ASCII characters in APRS packets are replaced!
 
 ## Getting started
 aprs2influxdb installs using pip can can be installed in editable mode with the source code or from [PyPI](https://pypi.python.org/pypi).

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -258,7 +258,8 @@ def parseUncompressed(jsonData):
 
 
 def parseMicE(jsonData):
-    """Parse mic-e APRS packets into influxedb line protocol
+    """Parse mic-e APRS packets into influxedb line protocol. Returns a
+    valid line protocol string.
 
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
@@ -293,50 +294,58 @@ def parseMicE(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits"]
     fieldTextKeys = ["via", "to", "mtype", "daodatumbyte"]
 
+    # Extract number fields from packet
     for key in fieldNumKeys:
         if key in jsonData:
             fields.append("{0}={1}".format(key, jsonData.get(key)))
+
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
+
+    # Extract comment
     if "comment" in jsonData:
         comment = parseTextString(jsonData.get("comment"), "comment")
         if len(jsonData.get("comment")) > 0:
             fields.append(comment)
         else:
             pass
-    # Extract raw from packet
+
+    # Extract raw packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract APRS symbol
     if "symbol" in jsonData:
         comment = parseTextString(jsonData.get("symbol"), "symbol")
         if len(jsonData.get("symbol")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract APRS symbol table
     if "symbol_table" in jsonData:
         comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
         if len(jsonData.get("symbol_table")) > 0:
             fields.append(comment)
-        else:
-            pass
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -10,10 +10,6 @@ import os
 
 from logging.handlers import TimedRotatingFileHandler
 
-# Globals
-#logging.basicConfig(level=logging.INFO)
-#logger = logging.getLogger("aprs2influxdb")
-
 # Command line input
 parser = argparse.ArgumentParser(description='Connects to APRS-IS and saves stream to local InfluxDB')
 parser.add_argument('--dbhost', help='Set InfluxDB host', default="localhost")

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -152,10 +152,10 @@ def parseUncompressed(jsonData):
         if jsonData["comment"]:
             fields.append(parseComment(jsonData["comment"]))
 
-    except KeyError as e:
-        logger.error("KeyError: {0}, Uncompressed Packet".format(e))
-        logger.error(jsonData)
-
+    except KeyError:
+        # Comment fields often are not present so just pass
+        pass
+    
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
@@ -221,9 +221,9 @@ def parseMicE(jsonData):
         if jsonData["comment"]:
             fields.append(parseComment(jsonData["comment"]))
 
-    except KeyError as e:
-        logger.error("KeyError: {0}, Mic-E Packet".format(e))
-        logger.error(jsonData)
+    except KeyError:
+        # Comment fields often are not present so just pass
+        pass
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -40,27 +40,6 @@ def jsonToLineProtocol(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
-    # measurement = packet
-    # tag = from
-    # tag = to
-    # tag = symbolTable
-    # tag = symbol
-    # tag = format
-    # tag = comment
-    # field = latitude
-    # field = longitude
-    # field = posAmbiguity
-    # field = altitude
-    # field = speed
-    # field = sequenceNumber
-    # field = analog1
-    # field = analog2
-    # field = analog3
-    # field = analog4
-    # field = analog5
-    # field = digital
 
     # Parse uncompressed format packets
     if jsonData["format"] == "uncompressed":
@@ -74,6 +53,50 @@ def parseUncompressed(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
+    # Converts aprslib JSON to influxdb line protocol
+    # Schema
+    # measurement = packet
+    # tag = from*
+    # tag = to*
+    # tag = symbolTable
+    # tag = symbol
+    # tag = format*
+    # tag = objectFormat
+    # tag = objectName
+    # tag = via
+    # tag = messageCapable
+    # field = timestamp
+    # field = rawTimestamp
+    # field = latitude*
+    # field = longitude*
+    # field = posAmbiguity*
+    # field = altitude*
+    # field = speed
+    # field = course
+    # field = seq*
+    # field = analog1*
+    # field = analog2*
+    # field = analog3*
+    # field = analog4*
+    # field = analog5*
+    # field = bits*
+    # field = comment*
+    # field = path
+    # field = mbits
+    # field = mtype
+    # field = pressure
+    # field = rain1H
+    # field = rain24h
+    # field = rainSinceMidnight
+    # field = temperature
+    # field = windDirection
+    # field = windGust
+    # field = windSpeed
+    # field = wxRawTimestamp
+    # field = status
+    # field = addresse
+    # field = messageText
+
     # initialize variables
     tags = []
     fields = []

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -339,8 +339,8 @@ def parseObject(jsonData):
     # measurement = packet
     # tag = from
     # field = to
-    # field = symbol_table* (SKIPPED)
-    # field = symbol* (SKIPPED)
+    # field = symbol_table
+    # field = symbol
     # tag = format
     # field = via
     # field = alive
@@ -518,8 +518,8 @@ def parseCompressed(jsonData):
     # measurement = packet
     # tag = from
     # field = to
-    # field = symbol_table* (SKIPPED)
-    # field = symbol* (SKIPPED)
+    # field = symbol_table
+    # field = symbol
     # tag = format
     # field = via
     # field = messagecapable
@@ -593,6 +593,20 @@ def parseCompressed(jsonData):
         if "raw" in jsonData:
             comment = parseTextString(jsonData.get("raw"), "raw")
             if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
+        # Extract symbol from packet
+        if "symbol" in jsonData:
+            comment = parseTextString(jsonData.get("symbol"), "symbol")
+            if len(jsonData.get("symbol")) > 0:
+                fields.append(comment)
+            else:
+                pass
+        # Extract symbol from packet
+        if "symbol_table" in jsonData:
+            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+            if len(jsonData.get("symbol_table")) > 0:
                 fields.append(comment)
             else:
                 pass

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -116,7 +116,7 @@ def parseUncompressed(jsonData):
     # field = analog5*
     # field = bits*
     # field = comment*
-    # field = path
+    # field = path*
     # field = mbits
     # field = mtype
     # field = pressure
@@ -155,6 +155,9 @@ def parseUncompressed(jsonData):
         fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
         fields.append("altitude={0}".format(jsonData.get("altitude", 0)))
         fields.append("speed={0}".format(jsonData.get("speed", 0)))
+        if jsonData.get("path"):
+            fields.append(parsePath(jsonData.get("path")))
+
     except KeyError as e:
         logger.error(e)
 
@@ -206,7 +209,7 @@ def parseMicE(jsonData):
     # field = speed*
     # field = course*
     # field = comment*
-    # field = path
+    # field = path*
     # field = mbits*
     # field = mtype*
 
@@ -238,6 +241,9 @@ def parseMicE(jsonData):
         fields.append("course={0}".format(jsonData.get("course", 0)))
         fields.append("mbits={0}".format(jsonData.get("mbits", 0)))
         fields.append("mtype=\"{0}\"".format(jsonData.get("mtype", 0)))
+        if jsonData.get("path"):
+            fields.append(parsePath(jsonData.get("path")))
+
     except KeyError as e:
         logger.error("KeyError: {0}, Mic-E Packet".format(e))
         logger.error(jsonData)
@@ -280,7 +286,7 @@ def parseObject(jsonData):
     # field = speed*
     # field = course*
     # field = comment*
-    # field = path
+    # field = path*
 
     # initialize variables
     tags = []
@@ -312,6 +318,8 @@ def parseObject(jsonData):
         fields.append("timestamp={0}".format(jsonData.get("timestamp", 0)))
         fields.append("objectFormat=\"{0}\"".format(jsonData.get("object_format")))
         fields.append("objectName=\"{0}\"".format(jsonData.get("object_name")))
+        if jsonData.get("path"):
+            fields.append(parsePath(jsonData.get("path")))
 
     except KeyError as e:
         logger.error("KeyError: {0}, Object Packet".format(e))
@@ -344,7 +352,7 @@ def parseStatus(jsonData):
     # tag = format*
     # tag = via*
     # field = status*
-    # field = path
+    # field = path*
 
     # initialize variables
     tags = []
@@ -367,6 +375,9 @@ def parseStatus(jsonData):
 
 
     fields.append(parseStatusValue(jsonData["status"]))
+    if jsonData.get("path"):
+        fields.append(parsePath(jsonData.get("path")))
+
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
@@ -400,7 +411,7 @@ def parseCompressed(jsonData):
     # field = analog5*
     # field = bits*
     # field = comment*
-    # field = path
+    # field = path*
 
     # initialize variables
     tags = []
@@ -425,6 +436,8 @@ def parseCompressed(jsonData):
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("altitude={0}".format(jsonData.get("altitude", 0)))
         fields.append("gpsFixStatus={0}".format(jsonData.get("gpsfixstatus", 0)))
+        if jsonData.get("path"):
+            fields.append(parsePath(jsonData.get("path")))
 
     except KeyError as e:
         logger.error(e)
@@ -479,7 +492,7 @@ def parseWX(jsonData):
     # field = windDirection
     # field = windGust
     # field = windSpeed
-    # field = path
+    # field = path*
 
     # initialize variables
     tags = []
@@ -510,6 +523,8 @@ def parseWX(jsonData):
         fields.append("windDirection={0}".format(jsonData.get("wind_direction", 0)))
         fields.append("windGust={0}".format(jsonData.get("wind_gust", 0)))
         fields.append("windSpeed={0}".format(jsonData.get("wind_speed", 0)))
+        if jsonData.get("path"):
+            fields.append(parsePath(jsonData.get("path")))
 
     except KeyError as e:
         logger.error("KeyError: {0}, Object Packet".format(e))
@@ -542,7 +557,7 @@ def parseBeacon(jsonData):
     # tag = format
     # tag = via
     # field = text*
-    # field = path
+    # field = path*
 
     # initialize variables
     tags = []
@@ -565,6 +580,9 @@ def parseBeacon(jsonData):
 
 
     fields.append(parseTextValue(jsonData["text"]))
+    if jsonData.get("path"):
+        fields.append(parsePath(jsonData.get("path")))
+
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
@@ -585,7 +603,7 @@ def parseBulletin(jsonData):
     # field = messageText
     # field = bid
     # field = identifier (empty)
-    # field = path
+    # field = path*
 
     # initialize variables
     tags = []
@@ -618,6 +636,8 @@ def parseBulletin(jsonData):
     fields.append("bid={0}".format(jsonData.get("bid", 0)))
     if jsonData.get("identifier"):
         fields.append("identifier={0}".format(jsonData.get("identifier")))
+    if jsonData.get("path"):
+        fields.append(parsePath(jsonData.get("path")))
 
     fieldsStr = ",".join(fields)
 
@@ -641,7 +661,7 @@ def parseMessage(jsonData):
     # field = messageText
     # field = bid
     # field = identifier (empty)
-    # field = path
+    # field = path*
 
     # initialize variables
     tags = []
@@ -675,6 +695,8 @@ def parseMessage(jsonData):
     fields.append("bid={0}".format(jsonData.get("bid", 0)))
     if jsonData.get("identifier"):
         fields.append("identifier={0}".format(jsonData.get("identifier")))
+    if jsonData.get("path"):
+        fields.append(parsePath(jsonData.get("path")))
 
     fieldsStr = ",".join(fields)
 
@@ -736,6 +758,19 @@ def parseMessageText(rawText):
 
     logger.error(textStr)
     return textStr
+
+
+def parsePath(path):
+    """Take path and turn into a string
+
+    keyword arguments:
+    path -- list of paths
+    """
+
+    temp = ",".join(path)
+    pathStr = ("path=\"{0}\"".format(temp))
+
+    return pathStr
 
 
 def callback(packet):

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -754,32 +754,38 @@ def parseBeacon(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldTextKeys = ["to", "via"]
 
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
+
+    # Extract text
     if "text" in jsonData:
         comment = parseTextString(jsonData.get("text"), "text")
         if len(jsonData.get("text")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract raw from packet
+
+    # Extract raw packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
@@ -811,42 +817,50 @@ def parseBulletin(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldNumKeys = ["bid"]
     fieldTextKeys = ["to", "via"]
 
+    # Extract number fields from packet
     for key in fieldNumKeys:
         if key in jsonData:
             fields.append("{0}={1}".format(key, jsonData.get(key)))
+
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
+
+    # Extract message text
     if "message_text" in jsonData:
         message = parseTextString(jsonData.get("message_text"), "message_text")
         if len(jsonData.get("message_text")) > 0:
             fields.append(message)
-        else:
-            pass
+
+    # Extract identifier
     if "identifier" in jsonData:
         identifier = parseTextString(jsonData.get("identifier"), "identifier")
         if len(jsonData.get("identifier")) > 0:
             fields.append(identifier)
-        else:
-            pass
-    # Extract raw from packet
+
+    # Extract raw packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -487,45 +487,53 @@ def parseStatus(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldNumKeys = ["timestamp"]
     fieldTextKeys = ["via", "to"]
 
+    # Extract number fields from packet
     for key in fieldNumKeys:
         if key in jsonData:
             fields.append("{0}={1}".format(key, jsonData.get(key)))
+
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
+
+    # Extract telemetry
     fields = parseTelemetry(jsonData, fields)
 
+    # Extract status
     if "status" in jsonData:
         comment = parseTextString(jsonData.get("status"), "status")
         if len(jsonData.get("status")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract raw from packet
+
+    # Extract raw packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract raw_timestamp from packet
+
+    # Extract raw timestamp
     if "raw_timestamp" in jsonData:
         rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
         if len(jsonData.get("raw_timestamp")) > 0:
             fields.append(rawtimestamp)
-        else:
-            pass
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -146,8 +146,7 @@ def parseUncompressed(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # field = from
     # field = to
     # field = symbol_table
@@ -265,10 +264,9 @@ def parseMicE(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # measurement = packet
-    # tag = from
+    # field = from
     # field = symbol_table
     # field = symbol
     # tag = format
@@ -296,7 +294,6 @@ def parseMicE(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -361,7 +358,7 @@ def parseObject(jsonData):
     # Converts aprslib JSON to influxdb line protocol
     # Schema
     # measurement = packet
-    # tag = from
+    # field = from
     # field = to
     # field = symbol_table
     # field = symbol
@@ -468,10 +465,9 @@ def parseStatus(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # measurement = packet
-    # tag = from
+    # field = from
     # field = to
     # tag = format
     # field = via
@@ -489,7 +485,6 @@ def parseStatus(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -546,10 +541,9 @@ def parseCompressed(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # measurement = packet
-    # tag = from
+    # field = from
     # field = to
     # field = symbol_table
     # field = symbol
@@ -591,7 +585,6 @@ def parseCompressed(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -657,10 +650,9 @@ def parseWX(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # measurement = packet*
-    # tag = from
+    # field = from
     # field = to
     # tag = format
     # field = via
@@ -686,7 +678,6 @@ def parseWX(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -737,10 +728,9 @@ def parseBeacon(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # measurement = packet
-    # tag = from
+    # field = from
     # field = to
     # tag = format
     # field = via
@@ -756,7 +746,6 @@ def parseBeacon(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -798,10 +787,9 @@ def parseBulletin(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # measurement = packet
-    # tag = from
+    # field = from
     # field = to
     # tag = format
     # field = via
@@ -819,7 +807,6 @@ def parseBulletin(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -873,10 +860,9 @@ def parseMessage(jsonData):
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
     """
-    # Converts aprslib JSON to influxdb line protocol
-    # Schema
+    ## Schema
     # measurement = packet
-    # tag = from
+    # field = from
     # field = to
     # tag = format
     # field = via
@@ -895,7 +881,6 @@ def parseMessage(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -167,7 +167,7 @@ def parseUncompressed(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course"]
-    fieldTextKeys = ["to", "messagecapable", "phg", "rng", "raw_timestamp", "via"]
+    fieldTextKeys = ["to", "messagecapable", "phg", "rng", "via"]
 
     # Extract fields from packet
     try:
@@ -211,6 +211,14 @@ def parseUncompressed(jsonData):
                 fields.append(comment)
             else:
                 pass
+        # Extract raw_timestamp from packet
+        if "raw_timestamp" in jsonData:
+            rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
+            if len(jsonData.get("raw_timestamp")) > 0:
+                fields.append(rawtimestamp)
+            else:
+                pass
+
 
         # Parse telemetry data if present
         fields = parseTelemetry(jsonData, fields)
@@ -385,7 +393,7 @@ def parseObject(jsonData):
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "speed", "course", "timestamp", "altitude"]
-    fieldTextKeys = ["alive", "via", "to", "raw_timestamp", "object_format", "object_name", "rng", "daodatumbyte"]
+    fieldTextKeys = ["alive", "via", "to", "object_format", "object_name", "rng", "daodatumbyte"]
 
     try:
         for key in fieldNumKeys:
@@ -422,6 +430,13 @@ def parseObject(jsonData):
             comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
             if len(jsonData.get("symbol_table")) > 0:
                 fields.append(comment)
+            else:
+                pass
+        # Extract raw_timestamp from packet
+        if "raw_timestamp" in jsonData:
+            rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
+            if len(jsonData.get("raw_timestamp")) > 0:
+                fields.append(rawtimestamp)
             else:
                 pass
 
@@ -470,7 +485,7 @@ def parseStatus(jsonData):
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["timestamp"]
-    fieldTextKeys = ["via", "to", "raw_timestamp"]
+    fieldTextKeys = ["via", "to"]
 
     try:
         for key in fieldNumKeys:
@@ -494,6 +509,13 @@ def parseStatus(jsonData):
             comment = parseTextString(jsonData.get("raw"), "raw")
             if len(jsonData.get("raw")) > 0:
                 fields.append(comment)
+            else:
+                pass
+        # Extract raw_timestamp from packet
+        if "raw_timestamp" in jsonData:
+            rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
+            if len(jsonData.get("raw_timestamp")) > 0:
+                fields.append(rawtimestamp)
             else:
                 pass
 
@@ -661,7 +683,7 @@ def parseWX(jsonData):
 
     tagStr = ",".join(tags)
 
-    fieldTextKeys = ["to", "via", "wx_raw_timestamp"]
+    fieldTextKeys = ["to", "via"]
 
     try:
         fields = parseWeather(jsonData, fields)
@@ -681,6 +703,13 @@ def parseWX(jsonData):
             comment = parseTextString(jsonData.get("raw"), "raw")
             if len(jsonData.get("raw")) > 0:
                 fields.append(comment)
+            else:
+                pass
+        # Extract wx_raw_timestamp from packet
+        if "wx_raw_timestamp" in jsonData:
+            rawtimestamp = parseTextString(jsonData.get("wx_raw_timestamp"), "wx_raw_timestamp")
+            if len(jsonData.get("wx_raw_timestamp")) > 0:
+                fields.append(rawtimestamp)
             else:
                 pass
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -113,8 +113,8 @@ def parseUncompressed(jsonData):
     # Schema
     # tag = from
     # field = to
-    # field = symbol_table* (SKIPPED)
-    # field = symbol* (SKIPPED)
+    # field = symbol_table
+    # field = symbol
     # tag = format
     # field = via
     # field = messagecapable
@@ -243,8 +243,8 @@ def parseMicE(jsonData):
     # Schema
     # measurement = packet
     # tag = from
-    # field = symbol_table* (SKIPPED)
-    # field = symbol* (SKIPPED)
+    # field = symbol_table
+    # field = symbol
     # tag = format
     # field = via
     # field = latitude
@@ -301,6 +301,20 @@ def parseMicE(jsonData):
         if "raw" in jsonData:
             comment = parseTextString(jsonData.get("raw"), "raw")
             if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
+        # Extract symbol from packet
+        if "symbol" in jsonData:
+            comment = parseTextString(jsonData.get("symbol"), "symbol")
+            if len(jsonData.get("symbol")) > 0:
+                fields.append(comment)
+            else:
+                pass
+        # Extract symbol from packet
+        if "symbol_table" in jsonData:
+            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+            if len(jsonData.get("symbol_table")) > 0:
                 fields.append(comment)
             else:
                 pass

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -203,6 +203,13 @@ def parseUncompressed(jsonData):
                 fields.append(comment)
             else:
                 pass
+        # Extract symbol from packet
+        if "symbol_table" in jsonData:
+            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+            if len(jsonData.get("symbol_table")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
         # Parse telemetry data if present
         fields = parseTelemetry(jsonData, fields)

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -259,8 +259,8 @@ def parseObject(jsonData):
     # tag = format*
     # tag = via
     # tag = alive*
-    # tag = objectFormat*
-    # tag = objectName*
+    # field = objectFormat*
+    # field = objectName*
     # field = latitude*
     # field = longitude*
     # field = posAmbiguity*
@@ -285,8 +285,6 @@ def parseObject(jsonData):
             tags.append("via={0}".format(jsonData.get("via")))
         tags.append("format={0}".format(jsonData.get("format")))
         tags.append("alive={0}".format(jsonData.get("alive")))
-        #tags.append("objectFormat={0}".format(jsonData.get("object_format")))
-        #tags.append("objectName=\"{0}\"".format(jsonData.get("object_name")))
 
     except KeyError as e:
         logger.error(e)
@@ -301,6 +299,8 @@ def parseObject(jsonData):
         fields.append("course={0}".format(jsonData.get("course", 0)))
         fields.append("rawTimestamp=\"{0}\"".format(jsonData.get("raw_timestamp", 0)))
         fields.append("timestamp={0}".format(jsonData.get("timestamp", 0)))
+        fields.append("objectFormat=\"{0}\"".format(jsonData.get("object_format")))
+        fields.append("objectName=\"{0}\"".format(jsonData.get("object_name")))
 
     except KeyError as e:
         logger.error("KeyError: {0}, Object Packet".format(e))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -84,6 +84,8 @@ def jsonToLineProtocol(jsonData):
 def parseTelemetry(jsonData, fieldList):
     if "telemetry" in jsonData:
         items = jsonData.get("telemetry")
+        if "seq" in items:
+            fieldList.append("seq={0}".format(items.get("seq")))
         if "bits" in items:
             fieldList.append("bits={0}".format(items.get("bits")))
         if "vals" in items:

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -171,7 +171,12 @@ def parseUncompressed(jsonData):
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         if "comment" in jsonData:
-            fields.append(parseTextString(jsonData.get("comment"), "comment"))
+            comment = parseTextString(jsonData.get("comment"), "comment")
+            if len(jsonData.get("comment")) > 0:
+                pass
+                fields.append(comment)
+            else:
+                pass
         fields = parseTelemetry(jsonData, fields)
 
     except KeyError as e:
@@ -720,23 +725,23 @@ def parseMessage(jsonData):
 
 
 def parseTextString(rawText, name):
-    if len(rawText) == "\\":
-        logger.error(rawText)
-    try:
-        text = rawText.encode('ascii', 'ignore')
-        if text == "\\":
-            logger.error(text)
-        else:
-            text = text.replace("\"", "\\\"")  # Remove quotes per line protocol
-        textStr = ("{0}=\"{1}\"".format(name, text))
+    if len(rawText) > 0:
+        try:
+            text = rawText.encode('ascii', 'replace')
+            text = text.replace("\'", "\\\'")
+            text = text.replace("\"", "\\\"")
+            textStr = ("{0}=\"{1}\"".format(name, text))
 
-    except UnicodeError as e:
-        logger.error(e)
+        except UnicodeError as e:
+            logger.error(e)
 
-    except TypeError as e:
-        logger.error(e)
+        except TypeError as e:
+            logger.error(e)
 
-    return textStr
+        return textStr
+
+    else:
+        return rawText
 
 
 def parsePath(path):

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -1040,7 +1040,9 @@ def consumer(conn):
     keyword arguments:
     conn -- APRS-IS connection from aprslib
     """
+
     logger.debug("starting consumer thread")
+
     # Obtain raw APRS-IS packets and sent to callback when received
     conn.consumer(callback, immortal=True, raw=False)
 
@@ -1051,8 +1053,9 @@ def heartbeat(conn, callsign, interval):
     keyword arguments:
     conn -- APRS-IS connction from aprslib
     callsign -- Callsign of status message
-    interval -- Minutes betwee status messages
+    interval -- Minutes between status messages
     """
+
     logger.debug("Starting heartbeat thread")
     while True:
         # Create timestamp
@@ -1122,18 +1125,20 @@ def main():
                      passwd=passcode,
                      port=args.port)
 
+    # Set aprslib logger equal to aprs2influxdb logger
     AIS.logger = logger
+
+    # Connect to APRS-IS servers
     try:
         AIS.connect()
 
-    except aprslib.exceptions.LoginError as e:
-        logger.error(e)
-        logger.info("APRS Login Callsign: {0} Port: {1}".format(args.callsign, args.port))
-        sys.exit(1)
+    except aprslib.exceptions.LoginError:
+        # An error occured
+        logger.error('An aprslib LoginError occured', exc_info=True)
 
     except aprslib.exceptions.ConnectionError as e:
-        logger.error(e)
-        sys.exit(1)
+        # An error occured
+        logger.error('An aprslib ConnectionError occured', exc_info=True)
 
     # Create heartbeat
     t1 = threading.Thread(target=heartbeat, args=(AIS, args.callsign, args.interval))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -982,12 +982,14 @@ def parsePath(path):
     """Take path and turn into a string
 
     keyword arguments:
-    path -- list of paths
+    path -- list of paths from aprslib
     """
 
+    # Join path items into a string separated by commas, valid line protocol
     temp = ",".join(path)
     pathStr = ("path=\"{0}\"".format(temp))
 
+    # Return line protocol string
     return pathStr
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -196,7 +196,8 @@ def parseMicE(jsonData):
     try:
         tags.append("from={0}".format(jsonData.get("from")))
         tags.append("to={0}".format(jsonData.get("to")))
-        tags.append("via={0}".format(jsonData.get("via")))
+        if jsonData.get("via"):
+            tags.append("via={0}".format(jsonData.get("via")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -269,8 +270,6 @@ def parseObject(jsonData):
         tags.append("to={0}".format(jsonData.get("to")))
         if jsonData.get("via"):
             tags.append("via={0}".format(jsonData.get("via")))
-        else:
-            logger.error("SKIPPED")
         tags.append("format={0}".format(jsonData.get("format")))
         tags.append("alive={0}".format(jsonData.get("alive")))
         #tags.append("objectFormat={0}".format(jsonData.get("object_format")))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -600,20 +600,6 @@ def parseBeacon(jsonData):
         # Expect many KeyErrors for stations not sending telemetry
         pass
 
-    # fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    # if jsonData.get("via"):
-    #     fields.append("via=\"{0}\"".format(jsonData.get("via")))
-    # fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    #
-    # text = parseTextString(jsonData["text"], "text")
-    # if len(jsonData.get("text")) > 0:
-    #     fields.append(text)
-    # else:
-    #     pass
-    #
-    # if jsonData.get("path"):
-    #     fields.append(parsePath(jsonData.get("path")))
-
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -751,12 +751,13 @@ def parseMessageText(rawText):
         textStr = ("messageText=\"{0}\"".format(text.replace("\"", "")))
 
     except UnicodeError as e:
+        logger.error("UnicodeError: {0}".format(rawText))
         logger.error(e)
 
     except TypeError as e:
+        logger.error("TypeError: {0}".format(rawText))
         logger.error(e)
 
-    logger.error(textStr)
     return textStr
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -187,6 +187,7 @@ def parseUncompressed(jsonData):
 
     return measurement + "," + tagStr + " " + fieldsStr
 
+
 def parseMicE(jsonData):
     """Parse Mic-e APRS packets into influxedb line protocol
 
@@ -259,6 +260,7 @@ def parseMicE(jsonData):
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
+
 
 def parseObject(jsonData):
     """Parse Object APRS packets into influxedb line protocol
@@ -372,7 +374,6 @@ def parseStatus(jsonData):
         logger.error(e)
 
     tagStr = ",".join(tags)
-
 
     fields.append(parseStatusValue(jsonData["status"]))
     if jsonData.get("path"):
@@ -578,7 +579,6 @@ def parseBeacon(jsonData):
 
     tagStr = ",".join(tags)
 
-
     fields.append(parseTextValue(jsonData["text"]))
     if jsonData.get("path"):
         fields.append(parsePath(jsonData.get("path")))
@@ -586,6 +586,7 @@ def parseBeacon(jsonData):
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
+
 
 def parseBulletin(jsonData):
     """Parse Bulletin APRS packets into influxedb line protocol
@@ -623,7 +624,6 @@ def parseBulletin(jsonData):
         logger.error(e)
 
     tagStr = ",".join(tags)
-
 
     try:
         if jsonData["message_text"]:
@@ -683,7 +683,6 @@ def parseMessage(jsonData):
 
     tagStr = ",".join(tags)
 
-
     try:
         if jsonData["message_text"]:
             fields.append(parseMessageText(jsonData["message_text"]))
@@ -703,7 +702,6 @@ def parseMessage(jsonData):
     return measurement + "," + tagStr + " " + fieldsStr
 
 
-
 def parseComment(rawComment):
     try:
         comment = rawComment.encode('ascii', 'ignore')
@@ -716,6 +714,7 @@ def parseComment(rawComment):
         logger.error(e)
 
     return commentStr
+
 
 def parseStatusValue(rawStatus):
     try:

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -589,54 +589,62 @@ def parseCompressed(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "gpsfixstatus", "altitude", "speed", "course", "timestamp"]
     fieldTextKeys = ["to", "messagecapable", "phg", "via"]
 
+    # Extract number fields from packet
     for key in fieldNumKeys:
         if key in jsonData:
             fields.append("{0}={1}".format(key, jsonData.get(key)))
+
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
+
+    # Extract comment
     if "comment" in jsonData:
         comment = parseTextString(jsonData.get("comment"), "comment")
         if len(jsonData.get("comment")) > 0:
             fields.append(comment)
-        else:
-            pass
+
+    # Extract telemetry
     fields = parseTelemetry(jsonData, fields)
 
+    # Extract weather data
     fields = parseWeather(jsonData, fields)
 
-    # Extract raw from packet
+    # Extract raw packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract APRS symbol
     if "symbol" in jsonData:
         comment = parseTextString(jsonData.get("symbol"), "symbol")
         if len(jsonData.get("symbol")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract APRS symbol table
     if "symbol_table" in jsonData:
         comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
         if len(jsonData.get("symbol_table")) > 0:
             fields.append(comment)
-        else:
-            pass
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -177,7 +177,7 @@ def parseUncompressed(jsonData):
 
     try:
         if jsonData["comment"]:
-            fields.append(parseComment(jsonData["comment"]))
+            fields.append(parseTextString(jsonData["comment"], "comment"))
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -251,7 +251,7 @@ def parseMicE(jsonData):
 
     try:
         if jsonData["comment"]:
-            fields.append(parseComment(jsonData["comment"]))
+            fields.append(parseTextString(jsonData["comment"], "comment"))
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -329,7 +329,7 @@ def parseObject(jsonData):
 
     try:
         if jsonData["comment"]:
-            fields.append(parseComment(jsonData["comment"]))
+            fields.append(parseTextString(jsonData["comment"], "comment"))
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -375,7 +375,8 @@ def parseStatus(jsonData):
 
     tagStr = ",".join(tags)
 
-    fields.append(parseStatusValue(jsonData["status"]))
+    fields.append(parseTextString(jsonData["status"], "status"))
+
     if jsonData.get("path"):
         fields.append(parsePath(jsonData.get("path")))
 
@@ -459,7 +460,7 @@ def parseCompressed(jsonData):
 
     try:
         if jsonData["comment"]:
-            fields.append(parseComment(jsonData["comment"]))
+            fields.append(parseTextString(jsonData["comment"], "comment"))
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -533,7 +534,7 @@ def parseWX(jsonData):
 
     try:
         if jsonData["comment"]:
-            fields.append(parseComment(jsonData["comment"]))
+            fields.append(parseTextString(jsonData["comment"], "comment"))
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -579,7 +580,8 @@ def parseBeacon(jsonData):
 
     tagStr = ",".join(tags)
 
-    fields.append(parseTextValue(jsonData["text"]))
+    fields.append(parseTextString(jsonData["text"], "text"))
+
     if jsonData.get("path"):
         fields.append(parsePath(jsonData.get("path")))
 
@@ -627,7 +629,7 @@ def parseBulletin(jsonData):
 
     try:
         if jsonData["message_text"]:
-            fields.append(parseMessageText(jsonData["message_text"]))
+            fields.append(parseTextString(jsonData["message_text"], "messageText"))
 
     except KeyError:
         # happens
@@ -685,7 +687,7 @@ def parseMessage(jsonData):
 
     try:
         if jsonData["message_text"]:
-            fields.append(parseMessageText(jsonData["message_text"]))
+            fields.append(parseTextString(jsonData["message_text"], "messageText"))
 
     except KeyError:
         # happens
@@ -702,64 +704,17 @@ def parseMessage(jsonData):
     return measurement + "," + tagStr + " " + fieldsStr
 
 
-def parseComment(rawComment):
-    try:
-        comment = rawComment.encode('ascii', 'ignore')
-        if comment != "\\":
-            comment = comment.replace("\"", "\\\"") # Remove quotes per line protocol
-        commentStr = ("comment=\"{0}\"".format(comment))
-
-    except UnicodeError as e:
-        logger.error(e)
-
-    except TypeError as e:
-        logger.error(e)
-
-    return commentStr
-
-
-def parseStatusValue(rawStatus):
-    try:
-        status = rawStatus.encode('ascii', 'ignore')
-        status = status.replace("\"", "\\\"") # Remove quotes per line protocol
-        statusStr = ("status=\"{0}\"".format(status))
-
-    except UnicodeError as e:
-        logger.error(e)
-
-    except TypeError as e:
-        logger.error(e)
-
-    return statusStr
-
-
-def parseTextValue(rawText):
+def parseTextString(rawText, name):
     try:
         text = rawText.encode('ascii', 'ignore')
-        text = text.replace("\"", "\\\"") # Remove quotes per line protocol
-        textStr = ("text=\"{0}\"".format(text))
+        if text != "\\":
+            text = text.replace("\"", "\\\"") # Remove quotes per line protocol
+        textStr = ("{0}=\"{1}\"".format(name, text))
 
     except UnicodeError as e:
         logger.error(e)
 
     except TypeError as e:
-        logger.error(e)
-
-    return textStr
-
-
-def parseMessageText(rawText):
-    try:
-        text = rawText.encode('ascii', 'ignore')
-        text = text.replace("\"", "\\\"") # Remove quotes per line protocol
-        textStr = ("messageText=\"{0}\"".format(text))
-
-    except UnicodeError as e:
-        logger.error("UnicodeError: {0}".format(rawText))
-        logger.error(e)
-
-    except TypeError as e:
-        logger.error("TypeError: {0}".format(rawText))
         logger.error(e)
 
     return textStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -185,7 +185,6 @@ def parseUncompressed(jsonData):
 
     fieldsStr = ",".join(fields)
 
-    logger.warning(measurement + "," + tagStr + " " + fieldsStr)
     return measurement + "," + tagStr + " " + fieldsStr
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -640,25 +640,34 @@ def parseBulletin(jsonData):
 
     tagStr = ",".join(tags)
 
+    fieldNumKeys = ["bid"]
+    fieldTextKeys = ["to"]
+
     try:
-        text = parseTextString(jsonData["message_text"], "messageText")
-        if len(jsonData.get("message_text")) > 0:
-            fields.append(text)
-        else:
-            pass
+        for key in fieldNumKeys:
+            if key in jsonData:
+                fields.append("{0}={1}".format(key,jsonData.get(key)))
+        for key in fieldTextKeys:
+            if key in jsonData:
+                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+        if "path" in jsonData:
+            fields.append(parsePath(jsonData.get("path")))
+        if "message_text" in jsonData:
+            message = parseTextString(jsonData.get("message_text"), "message_text")
+            if len(jsonData.get("message_text")) > 0:
+                fields.append(message)
+            else:
+                pass
+        if "identifier" in jsonData:
+            identifier = parseTextString(jsonData.get("identifier"), "identifier")
+            if len(jsonData.get("identifier")) > 0:
+                fields.append(identifier)
+            else:
+                pass
 
-    except KeyError:
-        # happens
+    except KeyError as e:
+        # Expect many KeyErrors for stations not sending telemetry
         pass
-
-    if jsonData.get("via"):
-        fields.append("via=\"{0}\"".format(jsonData.get("via")))
-    fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    fields.append("bid=\"{0}\"".format(jsonData.get("bid", 0)))
-    if jsonData.get("identifier"):
-        fields.append("identifier=\"{0}\"".format(jsonData.get("identifier")))
-    if jsonData.get("path"):
-        fields.append(parsePath(jsonData.get("path")))
 
     fieldsStr = ",".join(fields)
 
@@ -701,26 +710,34 @@ def parseMessage(jsonData):
 
     tagStr = ",".join(tags)
 
+    fieldNumKeys = ["msgNo"]
+    fieldTextKeys = ["to", "via", "addresse"]
+
     try:
-        text = parseTextString(jsonData["message_text"], "messageText")
-        if len(jsonData.get("message_text")) > 0:
-            fields.append(text)
-        else:
-            pass
+        for key in fieldNumKeys:
+            if key in jsonData:
+                fields.append("{0}={1}".format(key,jsonData.get(key)))
+        for key in fieldTextKeys:
+            if key in jsonData:
+                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+        if "path" in jsonData:
+            fields.append(parsePath(jsonData.get("path")))
+        if "message_text" in jsonData:
+            message = parseTextString(jsonData.get("message_text"), "message_text")
+            if len(jsonData.get("message_text")) > 0:
+                fields.append(message)
+            else:
+                pass
+        if "identifier" in jsonData:
+            identifier = parseTextString(jsonData.get("identifier"), "identifier")
+            if len(jsonData.get("identifier")) > 0:
+                fields.append(identifier)
+            else:
+                pass
 
-    except KeyError:
-        # happens
+    except KeyError as e:
+        # Expect many KeyErrors for stations not sending telemetry
         pass
-
-    fields.append("addresse=\"{0}\"".format(jsonData.get("addresse")))
-    if jsonData.get("via"):
-        fields.append("via=\"{0}\"".format(jsonData.get("via")))
-    fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    fields.append("bid=\"{0}\"".format(jsonData.get("bid", 0)))
-    if jsonData.get("identifier"):
-        fields.append("identifier={0}".format(jsonData.get("identifier")))
-    if jsonData.get("path"):
-        fields.append(parsePath(jsonData.get("path")))
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -113,8 +113,8 @@ def parseUncompressed(jsonData):
     # Schema
     # tag = from
     # field = to
-    # field = symbol_table*
-    # field = symbol*
+    # field = symbol_table* (SKIPPED)
+    # field = symbol* (SKIPPED)
     # tag = format
     # field = via*
     # field = messagecapable
@@ -145,7 +145,6 @@ def parseUncompressed(jsonData):
     # field = wind_direction*
     # field = wind_gust*
     # field = wind_speed*
-    # field = wx_raw_timestamp*
 
     # initialize variables
     tags = []
@@ -181,7 +180,7 @@ def parseUncompressed(jsonData):
         # Extract path and create string from list
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
-            
+
         # Extract comment from packet
         if "comment" in jsonData:
             comment = parseTextString(jsonData.get("comment"), "comment")
@@ -220,23 +219,27 @@ def parseMicE(jsonData):
     """
     # Converts aprslib JSON to influxdb line protocol
     # Schema
-    # measurement = packet*
-    # tag = from*
-    # field = dest*
-    # field = symbolTable
-    # field = symbol
-    # tag = format*
-    # field = via*
-    # field = latitude*
-    # field = longitude*
-    # field = posAmbiguity*
-    # field = altitude*
-    # field = speed*
-    # field = course*
-    # field = comment*
-    # field = path*
-    # field = mbits*
-    # field = mtype*
+    # measurement = packet
+    # tag = from
+    # field = symbol_table* (SKIPPED)
+    # field = symbol* (SKIPPED)
+    # tag = format
+    # field = via
+    # field = latitude
+    # field = longitude
+    # field = posambiguity
+    # field = altitude
+    # field = speed
+    # field = course
+    # field = comment
+    # field = path
+    # field = mbits
+    # field = mtype
+    # field = raw*
+    # field = to
+    # field = daodatumbyte*
+    # field = path
+
 
     # initialize variables
     tags = []
@@ -272,7 +275,6 @@ def parseMicE(jsonData):
                 fields.append(comment)
             else:
                 pass
-        fields = parseTelemetry(jsonData, fields)
 
     except KeyError as e:
         logger.error("KeyError: {0}, Mic-E Packet".format(e))
@@ -291,25 +293,36 @@ def parseObject(jsonData):
     """
     # Converts aprslib JSON to influxdb line protocol
     # Schema
-    # measurement = packet*
-    # tag = from*
+    # measurement = packet
+    # tag = from
     # field = to
-    # field = symbolTable
-    # field = symbol
-    # tag = format*
+    # field = symbol_table* (SKIPPED)
+    # field = symbol* (SKIPPED)
+    # tag = format
     # field = via
-    # field = alive*
-    # field = objectFormat*
-    # field = objectName*
-    # field = latitude*
-    # field = longitude*
-    # field = posAmbiguity*
-    # field = rawTimestamp*
-    # field = timestamp*
-    # field = speed*
-    # field = course*
-    # field = comment*
-    # field = path*
+    # field = alive
+    # field = object_format
+    # field = object_name
+    # field = latitude
+    # field = longitude
+    # field = posambiguity
+    # field = raw_timestamp
+    # field = timestamp
+    # field = speed
+    # field = course
+    # field = altitude*
+    # field = comment
+    # field = path
+    # field  = raw*
+    # field = daodatumbyte
+    # field = rng
+    # field = bits
+    # field = seq
+    # field = analog1
+    # field = analog2
+    # field = analog3
+    # field = analog4
+    # field = analog5
 
     # initialize variables
     tags = []
@@ -328,8 +341,8 @@ def parseObject(jsonData):
 
     tagStr = ",".join(tags)
 
-    fieldNumKeys = ["latitude", "longitude", "posambiguity", "speed", "course", "timestamp"]
-    fieldTextKeys = ["alive", "via", "to", "raw_timestamp", "object_format", "object_name"]
+    fieldNumKeys = ["latitude", "longitude", "posambiguity", "speed", "course", "timestamp", "altitude"]
+    fieldTextKeys = ["alive", "via", "to", "raw_timestamp", "object_format", "object_name", "rng", "daodatumbyte"]
 
     try:
         for key in fieldNumKeys:
@@ -365,13 +378,16 @@ def parseStatus(jsonData):
     """
     # Converts aprslib JSON to influxdb line protocol
     # Schema
-    # measurement = packet*
-    # tag = from*
-    # field = to*
-    # tag = format*
-    # field = via*
-    # field = status*
-    # field = path*
+    # measurement = packet
+    # tag = from
+    # field = to
+    # tag = format
+    # field = via
+    # field = status
+    # field = path
+    # field = timestamp
+    # field = raw*
+    # field = raw_timestamp
 
     # initialize variables
     tags = []
@@ -389,9 +405,13 @@ def parseStatus(jsonData):
 
     tagStr = ",".join(tags)
 
-    fieldTextKeys = ["via", "to"]
+    fieldNumKeys = ["timestamp"]
+    fieldTextKeys = ["via", "to", "raw_timestamp"]
 
     try:
+        for key in fieldNumKeys:
+            if key in jsonData:
+                fields.append("{0}={1}".format(key,jsonData.get(key)))
         for key in fieldTextKeys:
             if key in jsonData:
                 fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
@@ -424,26 +444,39 @@ def parseCompressed(jsonData):
     # Converts aprslib JSON to influxdb line protocol
     # Schema
     # measurement = packet
-    # tag = from*
-    # field = to*
-    # field = symbolTable
-    # field = symbol
-    # tag = format*
-    # field = via*
-    # field = messageCapable*
-    # field = latitude*
-    # field = longitude*
-    # field = gpsFixStatus*
-    # field = altitude*
-    # field = seq*
-    # field = analog1*
-    # field = analog2*
-    # field = analog3*
-    # field = analog4*
-    # field = analog5*
-    # field = bits*
-    # field = comment*
-    # field = path*
+    # tag = from
+    # field = to
+    # field = symbol_table* (SKIPPED)
+    # field = symbol* (SKIPPED)
+    # tag = format
+    # field = via
+    # field = messagecapable
+    # field = latitude
+    # field = longitude
+    # field = gpsfixstatus
+    # field = altitude
+    # field = seq
+    # field = analog1
+    # field = analog2
+    # field = analog3
+    # field = analog4
+    # field = analog5
+    # field = bits
+    # field = comment
+    # field = path
+    # field = phg
+    # field = raw*
+    # field = timestamp
+    # field = pressure
+    # field = rain_1h
+    # field = rain_24h
+    # field = rain_since_midnight
+    # field = temperature
+    # field = wind_direction
+    # field = wind_gust
+    # field = wind_speed
+    # field = speed
+    # field = course
 
     # initialize variables
     tags = []
@@ -454,7 +487,6 @@ def parseCompressed(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -462,8 +494,8 @@ def parseCompressed(jsonData):
 
     tagStr = ",".join(tags)
 
-    fieldNumKeys = ["latitude","longitude","gpsfixstatus","altitude"]
-    fieldTextKeys = ["to", "messagecapable"]
+    fieldNumKeys = ["latitude","longitude","gpsfixstatus","altitude", "speed", "course", "timestamp"]
+    fieldTextKeys = ["to", "messagecapable", "phg", "via"]
     fieldTelemetryKeys = ["seq","bits"]
 
     try:
@@ -482,6 +514,8 @@ def parseCompressed(jsonData):
             else:
                 pass
         fields = parseTelemetry(jsonData, fields)
+
+        fields = parseWeather(jsonData, fields)
 
     except KeyError as e:
         # Expect many KeyErrors for stations not sending telemetry
@@ -505,18 +539,19 @@ def parseWX(jsonData):
     # field = to
     # tag = format
     # field = via
-    # field = wxRawTimestamp
+    # field = wx_raw_timestamp
     # field = comment
     # field = humidity
     # field = pressure
-    # field = rain1h
-    # field = rain24h
-    # field = rainSinceMidnight
+    # field = rain_1h
+    # field = rain_24h
+    # field = rain_since_midnight
     # field = temperature
-    # field = windDirection
-    # field = windGust
-    # field = windSpeed
-    # field = path*
+    # field = wind_direction
+    # field = wind_gust
+    # field = wind_speed
+    # field = path
+    # field = raw*
 
     # initialize variables
     tags = []
@@ -572,8 +607,10 @@ def parseBeacon(jsonData):
     # field = to
     # tag = format
     # field = via
-    # field = text*
-    # field = path*
+    # field = text
+    # field = path
+    # field = raw*
+
 
     # initialize variables
     tags = []
@@ -629,10 +666,11 @@ def parseBulletin(jsonData):
     # field = to
     # tag = format
     # field = via
-    # field = messageText
+    # field = message_text
     # field = bid
-    # field = identifier (empty)
-    # field = path*
+    # field = identifier
+    # field = path
+    # field = raw*
 
     # initialize variables
     tags = []
@@ -643,7 +681,6 @@ def parseBulletin(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -652,7 +689,7 @@ def parseBulletin(jsonData):
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["bid"]
-    fieldTextKeys = ["to"]
+    fieldTextKeys = ["to", "via"]
 
     try:
         for key in fieldNumKeys:
@@ -699,10 +736,11 @@ def parseMessage(jsonData):
     # tag = format
     # field = via
     # field = addresse
-    # field = messageText
-    # field = bid
-    # field = identifier (empty)
-    # field = path*
+    # field = message_text
+    # field = path
+    # field = raw*
+    # field = msgNo
+    # field = response
 
     # initialize variables
     tags = []
@@ -713,7 +751,6 @@ def parseMessage(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -733,16 +770,18 @@ def parseMessage(jsonData):
                 fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
+
         if "message_text" in jsonData:
             message = parseTextString(jsonData.get("message_text"), "message_text")
             if len(jsonData.get("message_text")) > 0:
                 fields.append(message)
             else:
                 pass
-        if "identifier" in jsonData:
-            identifier = parseTextString(jsonData.get("identifier"), "identifier")
-            if len(jsonData.get("identifier")) > 0:
-                fields.append(identifier)
+
+        if "response" in jsonData:
+            message = parseTextString(jsonData.get("response"), "response")
+            if len(jsonData.get("response")) > 0:
+                fields.append(message)
             else:
                 pass
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -705,7 +705,9 @@ def parseMessage(jsonData):
 def parseComment(rawComment):
     try:
         comment = rawComment.encode('ascii', 'ignore')
-        commentStr = ("comment=\"{0}\"".format(comment.replace("\"", "")))
+        if comment != "\\":
+            comment = comment.replace("\"", "\\\"") # Remove quotes per line protocol
+        commentStr = ("comment=\"{0}\"".format(comment))
 
     except UnicodeError as e:
         logger.error(e)
@@ -719,7 +721,8 @@ def parseComment(rawComment):
 def parseStatusValue(rawStatus):
     try:
         status = rawStatus.encode('ascii', 'ignore')
-        statusStr = ("status=\"{0}\"".format(status.replace("\"", "")))
+        status = status.replace("\"", "\\\"") # Remove quotes per line protocol
+        statusStr = ("status=\"{0}\"".format(status))
 
     except UnicodeError as e:
         logger.error(e)
@@ -733,7 +736,8 @@ def parseStatusValue(rawStatus):
 def parseTextValue(rawText):
     try:
         text = rawText.encode('ascii', 'ignore')
-        textStr = ("text=\"{0}\"".format(text.replace("\"", "")))
+        text = text.replace("\"", "\\\"") # Remove quotes per line protocol
+        textStr = ("text=\"{0}\"".format(text))
 
     except UnicodeError as e:
         logger.error(e)
@@ -747,7 +751,8 @@ def parseTextValue(rawText):
 def parseMessageText(rawText):
     try:
         text = rawText.encode('ascii', 'ignore')
-        textStr = ("messageText=\"{0}\"".format(text.replace("\"", "")))
+        text = text.replace("\"", "\\\"") # Remove quotes per line protocol
+        textStr = ("messageText=\"{0}\"".format(text))
 
     except UnicodeError as e:
         logger.error("UnicodeError: {0}".format(rawText))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -92,14 +92,14 @@ def parseUncompressed(jsonData):
     # Schema
     # measurement = packet
     # tag = from*
-    # tag = to*
-    # tag = symbolTable
-    # tag = symbol
+    # field = to*
+    # field = symbolTable
+    # field = symbol
     # tag = format*
-    # tag = objectFormat
-    # tag = objectName
-    # tag = via
-    # tag = messageCapable
+    # field = objectFormat
+    # field = objectName
+    # field = via
+    # field = messageCapable
     # field = timestamp
     # field = rawTimestamp
     # field = latitude*
@@ -141,7 +141,6 @@ def parseUncompressed(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -150,6 +149,7 @@ def parseUncompressed(jsonData):
     tagStr = ",".join(tags)
 
     try:
+        fields.append("to={0}".format(jsonData.get("to")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
@@ -185,6 +185,7 @@ def parseUncompressed(jsonData):
 
     fieldsStr = ",".join(fields)
 
+    logger.warning
     return measurement + "," + tagStr + " " + fieldsStr
 
 
@@ -199,10 +200,10 @@ def parseMicE(jsonData):
     # measurement = packet*
     # tag = from*
     # field = dest*
-    # tag = symbolTable
-    # tag = symbol
+    # field = symbolTable
+    # field = symbol
     # tag = format*
-    # tag = via*
+    # field = via*
     # field = latitude*
     # field = longitude*
     # field = posAmbiguity*
@@ -223,9 +224,6 @@ def parseMicE(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-
-        if jsonData.get("via"):
-            tags.append("via={0}".format(jsonData.get("via")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -234,6 +232,8 @@ def parseMicE(jsonData):
     tagStr = ",".join(tags)
 
     try:
+        if jsonData.get("via"):
+            fields.append("via={0}".format(jsonData.get("via")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
@@ -279,12 +279,12 @@ def parseObject(jsonData):
     # Schema
     # measurement = packet*
     # tag = from*
-    # tag = to
-    # tag = symbolTable
-    # tag = symbol
+    # field = to
+    # field = symbolTable
+    # field = symbol
     # tag = format*
-    # tag = via
-    # tag = alive*
+    # field = via
+    # field = alive*
     # field = objectFormat*
     # field = objectName*
     # field = latitude*
@@ -306,11 +306,8 @@ def parseObject(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
-        if jsonData.get("via"):
-            tags.append("via={0}".format(jsonData.get("via")))
+        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
-        tags.append("alive={0}".format(jsonData.get("alive")))
 
     except KeyError as e:
         logger.error(e)
@@ -318,6 +315,10 @@ def parseObject(jsonData):
     tagStr = ",".join(tags)
 
     try:
+        fields.append("alive={0}".format(jsonData.get("alive")))
+        if jsonData.get("via"):
+            fields.append("via={0}".format(jsonData.get("via")))
+        fields.append("to={0}".format(jsonData.get("to")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
@@ -357,9 +358,9 @@ def parseStatus(jsonData):
     # Schema
     # measurement = packet*
     # tag = from*
-    # tag = to*
+    # field = to*
     # tag = format*
-    # tag = via*
+    # field = via*
     # field = status*
     # field = path*
 
@@ -372,9 +373,7 @@ def parseStatus(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
-        if jsonData.get("via"):
-            tags.append("via={0}".format(jsonData.get("via")))
+        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -382,6 +381,9 @@ def parseStatus(jsonData):
 
     tagStr = ",".join(tags)
 
+    if jsonData.get("via"):
+        fields.append("via={0}".format(jsonData.get("via")))
+    fields.append("to={0}".format(jsonData.get("to")))
     fields.append(parseTextString(jsonData["status"], "status"))
 
     if jsonData.get("path"):
@@ -402,12 +404,12 @@ def parseCompressed(jsonData):
     # Schema
     # measurement = packet
     # tag = from*
-    # tag = to*
-    # tag = symbolTable
-    # tag = symbol
+    # field = to*
+    # field = symbolTable
+    # field = symbol
     # tag = format*
-    # tag = via*
-    # tag = messageCapable*
+    # field = via*
+    # field = messageCapable*
     # field = latitude*
     # field = longitude*
     # field = gpsFixStatus*
@@ -431,9 +433,8 @@ def parseCompressed(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
+        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
-        tags.append("messageCapable={0}".format(jsonData.get("messagecapable")))
 
     except KeyError as e:
         logger.error(e)
@@ -441,6 +442,8 @@ def parseCompressed(jsonData):
     tagStr = ",".join(tags)
 
     try:
+        fields.append("messageCapable={0}".format(jsonData.get("messagecapable")))
+        fields.append("to={0}".format(jsonData.get("to")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("altitude={0}".format(jsonData.get("altitude", 0)))
@@ -488,11 +491,12 @@ def parseWX(jsonData):
     # Schema
     # measurement = packet*
     # tag = from
-    # tag = to
+    # field = to
     # tag = format
-    # tag = via
+    # field = via
     # field = wxRawTimestamp
     # field = comment
+    # field = humidity
     # field = pressure
     # field = rain1h
     # field = rain24h
@@ -512,9 +516,7 @@ def parseWX(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
-        if jsonData.get("via"):
-            tags.append("via={0}".format(jsonData.get("via")))
+        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -523,7 +525,11 @@ def parseWX(jsonData):
     tagStr = ",".join(tags)
 
     try:
+        if jsonData.get("via"):
+            fields.append("via={0}".format(jsonData.get("via")))
+        fields.append("to={0}".format(jsonData.get("to")))
         fields.append("wxRawTimestamp={0}".format(jsonData.get("wx_raw_timestamp", 0)))
+        fields.append("humidity={0}".format(jsonData.get("humidity", 0)))
         fields.append("pressure={0}".format(jsonData.get("pressure", 0)))
         fields.append("rain1h={0}".format(jsonData.get("rain_1h", 0)))
         fields.append("rain24h={0}".format(jsonData.get("rain_24h", 0)))
@@ -562,9 +568,9 @@ def parseBeacon(jsonData):
     # Schema
     # measurement = packet
     # tag = from
-    # tag = to
+    # field = to
     # tag = format
-    # tag = via
+    # field = via
     # field = text*
     # field = path*
 
@@ -577,9 +583,6 @@ def parseBeacon(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
-        if jsonData.get("via"):
-            tags.append("via={0}".format(jsonData.get("via")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -587,6 +590,10 @@ def parseBeacon(jsonData):
 
     tagStr = ",".join(tags)
 
+    fields.append("to={0}".format(jsonData.get("to")))
+    if jsonData.get("via"):
+        fields.append("via={0}".format(jsonData.get("via")))
+    fields.append("to={0}".format(jsonData.get("to")))
     fields.append(parseTextString(jsonData["text"], "text"))
 
     if jsonData.get("path"):
@@ -607,9 +614,9 @@ def parseBulletin(jsonData):
     # Schema
     # measurement = packet
     # tag = from
-    # tag = to
+    # field = to
     # tag = format
-    # tag = via
+    # field = via
     # field = messageText
     # field = bid
     # field = identifier (empty)
@@ -624,9 +631,7 @@ def parseBulletin(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
-        if jsonData.get("via"):
-            tags.append("via={0}".format(jsonData.get("via")))
+        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -642,6 +647,9 @@ def parseBulletin(jsonData):
         # happens
         pass
 
+    if jsonData.get("via"):
+        fields.append("via={0}".format(jsonData.get("via")))
+    fields.append("to={0}".format(jsonData.get("to")))
     fields.append("bid={0}".format(jsonData.get("bid", 0)))
     if jsonData.get("identifier"):
         fields.append("identifier={0}".format(jsonData.get("identifier")))
@@ -663,10 +671,10 @@ def parseMessage(jsonData):
     # Schema
     # measurement = packet
     # tag = from
-    # tag = to
+    # field = to
     # tag = format
-    # tag = via
-    # tag = addresse
+    # field = via
+    # field = addresse
     # field = messageText
     # field = bid
     # field = identifier (empty)
@@ -681,11 +689,8 @@ def parseMessage(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
-        if jsonData.get("via"):
-            tags.append("via={0}".format(jsonData.get("via")))
+        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
-        tags.append("addresse={0}".format(jsonData.get("addresse")))
 
     except KeyError as e:
         logger.error(e)
@@ -700,6 +705,10 @@ def parseMessage(jsonData):
         # happens
         pass
 
+    fields.append("addresse={0}".format(jsonData.get("addresse")))
+    if jsonData.get("via"):
+        fields.append("via={0}".format(jsonData.get("via")))
+    fields.append("to={0}".format(jsonData.get("to")))
     fields.append("bid={0}".format(jsonData.get("bid", 0)))
     if jsonData.get("identifier"):
         fields.append("identifier={0}".format(jsonData.get("identifier")))
@@ -712,9 +721,13 @@ def parseMessage(jsonData):
 
 
 def parseTextString(rawText, name):
+    if len(rawText) == "\\":
+        logger.error(rawText)
     try:
         text = rawText.encode('ascii', 'ignore')
-        if text != "\\":
+        if text == "\\":
+            logger.error(text)
+        else:
             text = text.replace("\"", "\\\"")  # Remove quotes per line protocol
         textStr = ("{0}=\"{1}\"".format(name, text))
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -157,7 +157,7 @@ def parseUncompressed(jsonData):
         logger.error(e)
 
     tagStr = ",".join(tags)
-    fieldNumKeys = ["latitude","posambiguity","altitude","speed"]
+    fieldNumKeys = ["latitude","longitude","posambiguity","altitude","speed"]
     fieldTextKeys = ["to"]
     fieldTelemetryKeys = ["seq","bits"]
 
@@ -234,42 +234,29 @@ def parseMicE(jsonData):
 
     tagStr = ",".join(tags)
 
+    fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits"]
+    fieldTextKeys = ["via", "to", "mtype"]
+
     try:
-        if jsonData.get("via"):
-            fields.append("via=\"{0}\"".format(jsonData.get("via")))
-        fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
-        fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
-        fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
-        fields.append("altitude={0}".format(jsonData.get("altitude", 0)))
-        fields.append("speed={0}".format(jsonData.get("speed", 0)))
-        fields.append("course={0}".format(jsonData.get("course", 0)))
-        fields.append("mbits={0}".format(jsonData.get("mbits", 0)))
-        fields.append("mtype=\"{0}\"".format(jsonData.get("mtype", 0)))
-        if jsonData.get("path"):
+        for key in fieldNumKeys:
+            if key in jsonData:
+                fields.append("{0}={1}".format(key,jsonData.get(key)))
+        for key in fieldTextKeys:
+            if key in jsonData:
+                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+        if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
-
-    except KeyError as e:
-        logger.error("KeyError: {0}, Mic-E Packet".format(e))
-        logger.error(jsonData)
-
-    try:
         if "comment" in jsonData:
             comment = parseTextString(jsonData.get("comment"), "comment")
             if len(jsonData.get("comment")) > 0:
                 fields.append(comment)
             else:
                 pass
+        fields = parseTelemetry(jsonData, fields)
 
-    except KeyError:
-        # Comment fields often are not present so just pass
-        pass
-
-    try:
-        dest = "dest=\"{0}\"".format(jsonData.get("to"))
-        fields.append(dest)
-
-    except:
-        pass
+    except KeyError as e:
+        logger.error("KeyError: {0}, Mic-E Packet".format(e))
+        logger.error(jsonData)
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -122,7 +122,7 @@ def parseUncompressed(jsonData):
     # field = longitude
     # field = posAmbiguity
     # field = altitude
-    # field = raw*
+    # field = raw
     # field = speed
     # field = course
     # field = raw_timestamp
@@ -189,6 +189,13 @@ def parseUncompressed(jsonData):
                 fields.append(comment)
             else:
                 pass
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
         # Parse telemetry data if present
         fields = parseTelemetry(jsonData, fields)
@@ -236,9 +243,9 @@ def parseMicE(jsonData):
     # field = path
     # field = mbits
     # field = mtype
-    # field = raw*
+    # field = raw
     # field = to
-    # field = daodatumbyte*
+    # field = daodatumbyte
     # field = path
 
 
@@ -258,7 +265,7 @@ def parseMicE(jsonData):
 
     tagStr = ",".join(tags)
 
-    fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits"]
+    fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits", "daodatumbyte"]
     fieldTextKeys = ["via", "to", "mtype"]
 
     try:
@@ -273,6 +280,13 @@ def parseMicE(jsonData):
         if "comment" in jsonData:
             comment = parseTextString(jsonData.get("comment"), "comment")
             if len(jsonData.get("comment")) > 0:
+                fields.append(comment)
+            else:
+                pass
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
                 fields.append(comment)
             else:
                 pass
@@ -311,10 +325,10 @@ def parseObject(jsonData):
     # field = timestamp
     # field = speed
     # field = course
-    # field = altitude*
+    # field = altitude
     # field = comment
     # field = path
-    # field  = raw*
+    # field  = raw
     # field = daodatumbyte
     # field = rng
     # field = bits
@@ -361,6 +375,13 @@ def parseObject(jsonData):
             else:
                 pass
         fields = parseTelemetry(jsonData, fields)
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError as e:
         logger.error("KeyError: {0}, object Packet".format(e))
@@ -387,7 +408,7 @@ def parseStatus(jsonData):
     # field = status
     # field = path
     # field = timestamp
-    # field = raw*
+    # field = raw
     # field = raw_timestamp
 
     # initialize variables
@@ -423,6 +444,13 @@ def parseStatus(jsonData):
         if "status" in jsonData:
             comment = parseTextString(jsonData.get("status"), "status")
             if len(jsonData.get("status")) > 0:
+                fields.append(comment)
+            else:
+                pass
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
                 fields.append(comment)
             else:
                 pass
@@ -466,7 +494,7 @@ def parseCompressed(jsonData):
     # field = comment
     # field = path
     # field = phg
-    # field = raw*
+    # field = raw
     # field = timestamp
     # field = pressure
     # field = rain_1h
@@ -518,6 +546,14 @@ def parseCompressed(jsonData):
 
         fields = parseWeather(jsonData, fields)
 
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
+
     except KeyError as e:
         # Expect many KeyErrors for stations not sending telemetry
         pass
@@ -552,7 +588,7 @@ def parseWX(jsonData):
     # field = wind_gust
     # field = wind_speed
     # field = path
-    # field = raw*
+    # field = raw
 
     # initialize variables
     tags = []
@@ -585,6 +621,13 @@ def parseWX(jsonData):
                 fields.append(comment)
             else:
                 pass
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError as e:
         # Expect many KeyErrors for stations not sending telemetry
@@ -610,7 +653,7 @@ def parseBeacon(jsonData):
     # field = via
     # field = text
     # field = path
-    # field = raw*
+    # field = raw
 
 
     # initialize variables
@@ -644,6 +687,13 @@ def parseBeacon(jsonData):
                 fields.append(comment)
             else:
                 pass
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError as e:
         # Expect many KeyErrors for stations not sending telemetry
@@ -671,7 +721,7 @@ def parseBulletin(jsonData):
     # field = bid
     # field = identifier
     # field = path
-    # field = raw*
+    # field = raw
 
     # initialize variables
     tags = []
@@ -713,6 +763,13 @@ def parseBulletin(jsonData):
                 fields.append(identifier)
             else:
                 pass
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError as e:
         # Expect many KeyErrors for stations not sending telemetry
@@ -739,7 +796,7 @@ def parseMessage(jsonData):
     # field = addresse
     # field = message_text
     # field = path
-    # field = raw*
+    # field = raw
     # field = msgNo
     # field = response
 
@@ -783,6 +840,13 @@ def parseMessage(jsonData):
             message = parseTextString(jsonData.get("response"), "response")
             if len(jsonData.get("response")) > 0:
                 fields.append(message)
+            else:
+                pass
+        # Extract raw from packet
+        if "raw" in jsonData:
+            comment = parseTextString(jsonData.get("raw"), "raw")
+            if len(jsonData.get("raw")) > 0:
+                fields.append(comment)
             else:
                 pass
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -943,12 +943,24 @@ def parseMessage(jsonData):
 
 
 def parseTextString(rawText, name):
+    '''Parse text strings for invalid characters. Properly escape for
+    line protocol strings if found.
+
+    keyword arguments:
+    rawText -- String to be checked
+    name -- Name of field
+    '''
+
+    # Check if length is valid
     if len(rawText) > 0:
         try:
+            # Convert to ASCII and replace invalid characters
             text = rawText.encode('ascii', 'replace')
             text = text.replace("\\", "\\\\")
             text = text.replace("\'", "\\\'")
             text = text.replace("\"", "\\\"")
+
+            # Create valide libe protocol field string
             textStr = ("{0}=\"{1}\"".format(name, text))
 
         except UnicodeError as e:
@@ -957,9 +969,12 @@ def parseTextString(rawText, name):
         except TypeError as e:
             logger.error(e)
 
+        # Return text string if line protocol format
         return textStr
 
     else:
+        # rawText is <= 0
+        # Return text string if line protocol format
         return rawText
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -264,7 +264,6 @@ def parseMicE(jsonData):
     except:
         pass
 
-
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
@@ -716,7 +715,7 @@ def parseTextString(rawText, name):
     try:
         text = rawText.encode('ascii', 'ignore')
         if text != "\\":
-            text = text.replace("\"", "\\\"") # Remove quotes per line protocol
+            text = text.replace("\"", "\\\"")  # Remove quotes per line protocol
         textStr = ("{0}=\"{1}\"".format(name, text))
 
     except UnicodeError as e:

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -198,7 +198,7 @@ def parseMicE(jsonData):
     # Schema
     # measurement = packet*
     # tag = from*
-    # tag = to*
+    # field = dest*
     # tag = symbolTable
     # tag = symbol
     # tag = format*
@@ -223,7 +223,7 @@ def parseMicE(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("to={0}".format(jsonData.get("to")))
+
         if jsonData.get("via"):
             tags.append("via={0}".format(jsonData.get("via")))
         tags.append("format={0}".format(jsonData.get("format")))
@@ -256,6 +256,14 @@ def parseMicE(jsonData):
     except KeyError:
         # Comment fields often are not present so just pass
         pass
+
+    try:
+        dest = "dest=\"{0}\"".format(jsonData.get("to"))
+        fields.append(dest)
+
+    except:
+        pass
+
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -724,6 +724,7 @@ def parseWX(jsonData):
     # Obtain weather data
     fields = parseWeather(jsonData, fields)
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -149,7 +149,7 @@ def parseUncompressed(jsonData):
     tagStr = ",".join(tags)
 
     try:
-        fields.append("to={0}".format(jsonData.get("to")))
+        fields.append("to=\"{0}\"".format(jsonData.get("to")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
@@ -233,7 +233,7 @@ def parseMicE(jsonData):
 
     try:
         if jsonData.get("via"):
-            fields.append("via={0}".format(jsonData.get("via")))
+            fields.append("via=\"{0}\"".format(jsonData.get("via")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
@@ -315,10 +315,10 @@ def parseObject(jsonData):
     tagStr = ",".join(tags)
 
     try:
-        fields.append("alive={0}".format(jsonData.get("alive")))
+        fields.append("alive=\"{0}\"".format(jsonData.get("alive")))
         if jsonData.get("via"):
-            fields.append("via={0}".format(jsonData.get("via")))
-        fields.append("to={0}".format(jsonData.get("to")))
+            fields.append("via=\"{0}\"".format(jsonData.get("via")))
+        fields.append("to=\"{0}\"".format(jsonData.get("to")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
@@ -382,8 +382,8 @@ def parseStatus(jsonData):
     tagStr = ",".join(tags)
 
     if jsonData.get("via"):
-        fields.append("via={0}".format(jsonData.get("via")))
-    fields.append("to={0}".format(jsonData.get("to")))
+        fields.append("via=\"{0}\"".format(jsonData.get("via")))
+    fields.append("to=\"{0}\"".format(jsonData.get("to")))
     fields.append(parseTextString(jsonData["status"], "status"))
 
     if jsonData.get("path"):
@@ -442,8 +442,8 @@ def parseCompressed(jsonData):
     tagStr = ",".join(tags)
 
     try:
-        fields.append("messageCapable={0}".format(jsonData.get("messagecapable")))
-        fields.append("to={0}".format(jsonData.get("to")))
+        fields.append("messageCapable=\"{0}\"".format(jsonData.get("messagecapable")))
+        fields.append("to=\"{0}\"".format(jsonData.get("to")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
         fields.append("altitude={0}".format(jsonData.get("altitude", 0)))
@@ -526,8 +526,8 @@ def parseWX(jsonData):
 
     try:
         if jsonData.get("via"):
-            fields.append("via={0}".format(jsonData.get("via")))
-        fields.append("to={0}".format(jsonData.get("to")))
+            fields.append("via=\"{0}\"".format(jsonData.get("via")))
+        fields.append("to=\"{0}\"".format(jsonData.get("to")))
         fields.append("wxRawTimestamp={0}".format(jsonData.get("wx_raw_timestamp", 0)))
         fields.append("humidity={0}".format(jsonData.get("humidity", 0)))
         fields.append("pressure={0}".format(jsonData.get("pressure", 0)))
@@ -590,10 +590,10 @@ def parseBeacon(jsonData):
 
     tagStr = ",".join(tags)
 
-    fields.append("to={0}".format(jsonData.get("to")))
+    fields.append("to=\"{0}\"".format(jsonData.get("to")))
     if jsonData.get("via"):
-        fields.append("via={0}".format(jsonData.get("via")))
-    fields.append("to={0}".format(jsonData.get("to")))
+        fields.append("via=\"{0}\"".format(jsonData.get("via")))
+    fields.append("to=\"{0}\"".format(jsonData.get("to")))
     fields.append(parseTextString(jsonData["text"], "text"))
 
     if jsonData.get("path"):
@@ -648,11 +648,11 @@ def parseBulletin(jsonData):
         pass
 
     if jsonData.get("via"):
-        fields.append("via={0}".format(jsonData.get("via")))
-    fields.append("to={0}".format(jsonData.get("to")))
-    fields.append("bid={0}".format(jsonData.get("bid", 0)))
+        fields.append("via=\"{0}\"".format(jsonData.get("via")))
+    fields.append("to=\"{0}\"".format(jsonData.get("to")))
+    fields.append("bid=\"{0}\"".format(jsonData.get("bid", 0)))
     if jsonData.get("identifier"):
-        fields.append("identifier={0}".format(jsonData.get("identifier")))
+        fields.append("identifier=\"{0}\"".format(jsonData.get("identifier")))
     if jsonData.get("path"):
         fields.append(parsePath(jsonData.get("path")))
 
@@ -705,11 +705,11 @@ def parseMessage(jsonData):
         # happens
         pass
 
-    fields.append("addresse={0}".format(jsonData.get("addresse")))
+    fields.append("addresse=\"{0}\"".format(jsonData.get("addresse")))
     if jsonData.get("via"):
-        fields.append("via={0}".format(jsonData.get("via")))
-    fields.append("to={0}".format(jsonData.get("to")))
-    fields.append("bid={0}".format(jsonData.get("bid", 0)))
+        fields.append("via=\"{0}\"".format(jsonData.get("via")))
+    fields.append("to=\"{0}\"".format(jsonData.get("to")))
+    fields.append("bid=\"{0}\"".format(jsonData.get("bid", 0)))
     if jsonData.get("identifier"):
         fields.append("identifier={0}".format(jsonData.get("identifier")))
     if jsonData.get("path"):

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -893,44 +893,50 @@ def parseMessage(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldNumKeys = ["msgNo"]
     fieldTextKeys = ["to", "via", "addresse"]
 
+    # Extract number fields from packet
     for key in fieldNumKeys:
         if key in jsonData:
             fields.append("{0}={1}".format(key, jsonData.get(key)))
+
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
 
+    # Extract message text
     if "message_text" in jsonData:
         message = parseTextString(jsonData.get("message_text"), "message_text")
         if len(jsonData.get("message_text")) > 0:
             fields.append(message)
-        else:
-            pass
 
+    # Extract response
     if "response" in jsonData:
         message = parseTextString(jsonData.get("response"), "response")
         if len(jsonData.get("response")) > 0:
             fields.append(message)
-        else:
-            pass
+
     # Extract raw from packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -82,6 +82,7 @@ def jsonToLineProtocol(jsonData):
         logger.error('A parsing StandardError occured', exc_info=True)
         logger.error("Packet: {0}".format(jsonData))
 
+
 def parseTelemetry(jsonData, fieldList):
     '''parse telemetry from packets
 
@@ -1136,7 +1137,7 @@ def main():
         # An error occured
         logger.error('An aprslib LoginError occured', exc_info=True)
 
-    except aprslib.exceptions.ConnectionError as e:
+    except aprslib.exceptions.ConnectionError:
         # An error occured
         logger.error('An aprslib ConnectionError occured', exc_info=True)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -362,7 +362,6 @@ def parseStatus(jsonData):
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
-        #tags.append("to={0}".format(jsonData.get("to")))
         tags.append("format={0}".format(jsonData.get("format")))
 
     except KeyError as e:
@@ -370,17 +369,26 @@ def parseStatus(jsonData):
 
     tagStr = ",".join(tags)
 
-    if jsonData.get("via"):
-        fields.append("via=\"{0}\"".format(jsonData.get("via")))
-    fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    status = parseTextString(jsonData["status"], "status")
-    if len(jsonData.get("status")) > 0:
-        fields.append(status)
-    else:
-        pass
+    fieldTextKeys = ["via", "to"]
 
-    if jsonData.get("path"):
-        fields.append(parsePath(jsonData.get("path")))
+    try:
+        for key in fieldTextKeys:
+            if key in jsonData:
+                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+        if "path" in jsonData:
+            fields.append(parsePath(jsonData.get("path")))
+        fields = parseTelemetry(jsonData, fields)
+
+        if "status" in jsonData:
+            comment = parseTextString(jsonData.get("status"), "status")
+            if len(jsonData.get("status")) > 0:
+                fields.append(comment)
+            else:
+                pass
+
+    except KeyError as e:
+        logger.error("KeyError: {0}, object Packet".format(e))
+        logger.error(jsonData)
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -83,16 +83,33 @@ def jsonToLineProtocol(jsonData):
         logger.error("Packet: {0}".format(jsonData))
 
 def parseTelemetry(jsonData, fieldList):
+    '''parse telemetry from packets
+
+    Iterates through a telemetry formated packet to extra sequence, bits, and
+    values. These are placed into the fieldList which is returned at the end of
+    the function.
+
+    keyword arguments:
+    jsonData -- JSON packet from aprslib
+    fieldList -- list of field items currently parsed
+    '''
+
+    # Check for telemetry in packet
     if "telemetry" in jsonData:
         items = jsonData.get("telemetry")
+        # Extract telemetry sequency
         if "seq" in items:
             fieldList.append("seq={0}".format(items.get("seq")))
+        # Extract IO bits
         if "bits" in items:
             fieldList.append("bits={0}".format(items.get("bits")))
+        # Extra analog values
         if "vals" in items:
             values = items.get("vals")
             for analog in range(5):
                 fieldList.append("analog{0}={1}".format(analog + 1, values[analog]))
+
+    # Return fieldList with found items appended
     return fieldList
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -196,6 +196,13 @@ def parseUncompressed(jsonData):
                 fields.append(comment)
             else:
                 pass
+        # Extract symbol from packet
+        if "symbol" in jsonData:
+            comment = parseTextString(jsonData.get("symbol"), "symbol")
+            if len(jsonData.get("symbol")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
         # Parse telemetry data if present
         fields = parseTelemetry(jsonData, fields)

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -98,7 +98,6 @@ def parseWeather(jsonData, fieldList):
         items = jsonData.get("weather")
         for key in wxFields:
             if key in items:
-                logger.warning("{0}={1}".format(key,items.get(key)))
                 fieldList.append("{0}={1}".format(key,items.get(key)))
     return fieldList
 
@@ -596,7 +595,7 @@ def parseBeacon(jsonData):
                 fields.append(comment)
             else:
                 pass
-            
+
     except KeyError as e:
         # Expect many KeyErrors for stations not sending telemetry
         pass

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -41,46 +41,51 @@ def jsonToLineProtocol(jsonData):
     jsonData -- aprslib parsed JSON packet
     """
 
-    # Parse uncompressed format packets
-    if jsonData["format"] == "uncompressed":
-        # Parse uncompressed APRS packet
-        return parseUncompressed(jsonData)
+    try:
+        # Parse uncompressed format packets
+        if jsonData["format"] == "uncompressed":
+            # Parse uncompressed APRS packet
+            return parseUncompressed(jsonData)
 
-    if jsonData["format"] == "mic-e":
-        # Parse Mice-E APRS packet
-        return parseMicE(jsonData)
+        if jsonData["format"] == "mic-e":
+            # Parse Mice-E APRS packet
+            return parseMicE(jsonData)
 
-    if jsonData["format"] == "object":
-        # Parse Object APRS packet
-        return parseObject(jsonData)
+        if jsonData["format"] == "object":
+            # Parse Object APRS packet
+            return parseObject(jsonData)
 
-    if jsonData["format"] == "compressed":
-        # Parse Object APRS packet
-        return parseCompressed(jsonData)
+        if jsonData["format"] == "compressed":
+            # Parse Object APRS packet
+            return parseCompressed(jsonData)
 
-    if jsonData["format"] == "status":
-        # Parse status APRS packet
-        return parseStatus(jsonData)
+        if jsonData["format"] == "status":
+            # Parse status APRS packet
+            return parseStatus(jsonData)
 
-    if jsonData["format"] == "wx":
-        # Parse WX APRS packet
-        return parseWX(jsonData)
+        if jsonData["format"] == "wx":
+            # Parse WX APRS packet
+            return parseWX(jsonData)
 
-    if jsonData["format"] == "beacon":
-        # Parse WX APRS packet
-        return parseBeacon(jsonData)
+        if jsonData["format"] == "beacon":
+            # Parse WX APRS packet
+            return parseBeacon(jsonData)
 
-    if jsonData["format"] == "bulletin":
-        # Parse Bulletin APRS packet
-        return parseBulletin(jsonData)
+        if jsonData["format"] == "bulletin":
+            # Parse Bulletin APRS packet
+            return parseBulletin(jsonData)
 
-    if jsonData["format"] == "message":
-        # Parse Message APRS packet
-        return parseMessage(jsonData)
+        if jsonData["format"] == "message":
+            # Parse Message APRS packet
+            return parseMessage(jsonData)
 
-    # Uncomment for all other formats not yes parsed
-    #logger.warning(jsonData["format"])
+        # Uncomment for all other formats not yes parsed
+        #logger.warning(jsonData["format"])
 
+    except StandardError:
+        # An error occured
+        logger.error('A KeyError error occured', exc_info=True)
+        logger.error("Packet: {0}".format(jsonData))
 
 def parseTelemetry(jsonData, fieldList):
     if "telemetry" in jsonData:
@@ -156,12 +161,8 @@ def parseUncompressed(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
@@ -170,70 +171,60 @@ def parseUncompressed(jsonData):
     fieldTextKeys = ["to", "messagecapable", "phg", "rng", "via"]
 
     # Extract fields from packet
-    try:
-        for key in fieldNumKeys:
-            if key in jsonData:
-                fields.append("{0}={1}".format(key, jsonData.get(key)))
+    for key in fieldNumKeys:
+        if key in jsonData:
+            fields.append("{0}={1}".format(key, jsonData.get(key)))
 
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
 
-        # Extract path and create string from list
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
+    # Extract path and create string from list
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
 
-        # Extract comment from packet
-        if "comment" in jsonData:
-            comment = parseTextString(jsonData.get("comment"), "comment")
-            if len(jsonData.get("comment")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol" in jsonData:
-            comment = parseTextString(jsonData.get("symbol"), "symbol")
-            if len(jsonData.get("symbol")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol_table" in jsonData:
-            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
-            if len(jsonData.get("symbol_table")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw_timestamp from packet
-        if "raw_timestamp" in jsonData:
-            rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
-            if len(jsonData.get("raw_timestamp")) > 0:
-                fields.append(rawtimestamp)
-            else:
-                pass
+    # Extract comment from packet
+    if "comment" in jsonData:
+        comment = parseTextString(jsonData.get("comment"), "comment")
+        if len(jsonData.get("comment")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol" in jsonData:
+        comment = parseTextString(jsonData.get("symbol"), "symbol")
+        if len(jsonData.get("symbol")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol_table" in jsonData:
+        comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+        if len(jsonData.get("symbol_table")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw_timestamp from packet
+    if "raw_timestamp" in jsonData:
+        rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
+        if len(jsonData.get("raw_timestamp")) > 0:
+            fields.append(rawtimestamp)
+        else:
+            pass
 
 
-        # Parse telemetry data if present
-        fields = parseTelemetry(jsonData, fields)
+    # Parse telemetry data if present
+    fields = parseTelemetry(jsonData, fields)
 
-        # Parse weather data if present
-        fields = parseWeather(jsonData, fields)
-
-    except KeyError as e:
-        logger.error(e)
-
-    except ValueError as e:
-        logger.error(e)
-
-    except StandardError as e:
-        logger.error(e)
+    # Parse weather data if present
+    fields = parseWeather(jsonData, fields)
 
     # Combine all fields into a valid line protocol string
     fieldsStr = ",".join(fields)
@@ -278,58 +269,49 @@ def parseMicE(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits"]
     fieldTextKeys = ["via", "to", "mtype", "daodatumbyte"]
 
-    try:
-        for key in fieldNumKeys:
-            if key in jsonData:
-                fields.append("{0}={1}".format(key, jsonData.get(key)))
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
-        if "comment" in jsonData:
-            comment = parseTextString(jsonData.get("comment"), "comment")
-            if len(jsonData.get("comment")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol" in jsonData:
-            comment = parseTextString(jsonData.get("symbol"), "symbol")
-            if len(jsonData.get("symbol")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol_table" in jsonData:
-            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
-            if len(jsonData.get("symbol_table")) > 0:
-                fields.append(comment)
-            else:
-                pass
-
-    except KeyError as e:
-        logger.error("KeyError: {0}, Mic-E Packet".format(e))
-        logger.error(jsonData)
+    for key in fieldNumKeys:
+        if key in jsonData:
+            fields.append("{0}={1}".format(key, jsonData.get(key)))
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
+    if "comment" in jsonData:
+        comment = parseTextString(jsonData.get("comment"), "comment")
+        if len(jsonData.get("comment")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol" in jsonData:
+        comment = parseTextString(jsonData.get("symbol"), "symbol")
+        if len(jsonData.get("symbol")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol_table" in jsonData:
+        comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+        if len(jsonData.get("symbol_table")) > 0:
+            fields.append(comment)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 
@@ -382,67 +364,58 @@ def parseObject(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        #tags.append("to={0}".format(jsonData.get("to")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("to={0}".format(jsonData.get("to")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "speed", "course", "timestamp", "altitude"]
     fieldTextKeys = ["alive", "via", "to", "object_format", "object_name", "rng", "daodatumbyte"]
 
-    try:
-        for key in fieldNumKeys:
-            if key in jsonData:
-                fields.append("{0}={1}".format(key, jsonData.get(key)))
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
-        if "comment" in jsonData:
-            comment = parseTextString(jsonData.get("comment"), "comment")
-            if len(jsonData.get("comment")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        fields = parseTelemetry(jsonData, fields)
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol" in jsonData:
-            comment = parseTextString(jsonData.get("symbol"), "symbol")
-            if len(jsonData.get("symbol")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol_table" in jsonData:
-            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
-            if len(jsonData.get("symbol_table")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw_timestamp from packet
-        if "raw_timestamp" in jsonData:
-            rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
-            if len(jsonData.get("raw_timestamp")) > 0:
-                fields.append(rawtimestamp)
-            else:
-                pass
-
-    except KeyError as e:
-        logger.error("KeyError: {0}, object Packet".format(e))
-        logger.error(jsonData)
+    for key in fieldNumKeys:
+        if key in jsonData:
+            fields.append("{0}={1}".format(key, jsonData.get(key)))
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
+    if "comment" in jsonData:
+        comment = parseTextString(jsonData.get("comment"), "comment")
+        if len(jsonData.get("comment")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    fields = parseTelemetry(jsonData, fields)
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol" in jsonData:
+        comment = parseTextString(jsonData.get("symbol"), "symbol")
+        if len(jsonData.get("symbol")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol_table" in jsonData:
+        comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+        if len(jsonData.get("symbol_table")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw_timestamp from packet
+    if "raw_timestamp" in jsonData:
+        rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
+        if len(jsonData.get("raw_timestamp")) > 0:
+            fields.append(rawtimestamp)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 
@@ -475,53 +448,44 @@ def parseStatus(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["timestamp"]
     fieldTextKeys = ["via", "to"]
 
-    try:
-        for key in fieldNumKeys:
-            if key in jsonData:
-                fields.append("{0}={1}".format(key, jsonData.get(key)))
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
-        fields = parseTelemetry(jsonData, fields)
+    for key in fieldNumKeys:
+        if key in jsonData:
+            fields.append("{0}={1}".format(key, jsonData.get(key)))
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
+    fields = parseTelemetry(jsonData, fields)
 
-        if "status" in jsonData:
-            comment = parseTextString(jsonData.get("status"), "status")
-            if len(jsonData.get("status")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw_timestamp from packet
-        if "raw_timestamp" in jsonData:
-            rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
-            if len(jsonData.get("raw_timestamp")) > 0:
-                fields.append(rawtimestamp)
-            else:
-                pass
-
-    except KeyError as e:
-        logger.error("KeyError: {0}, object Packet".format(e))
-        logger.error(jsonData)
+    if "status" in jsonData:
+        comment = parseTextString(jsonData.get("status"), "status")
+        if len(jsonData.get("status")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw_timestamp from packet
+    if "raw_timestamp" in jsonData:
+        rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
+        if len(jsonData.get("raw_timestamp")) > 0:
+            fields.append(rawtimestamp)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 
@@ -578,62 +542,53 @@ def parseCompressed(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["latitude", "longitude", "gpsfixstatus", "altitude", "speed", "course", "timestamp"]
     fieldTextKeys = ["to", "messagecapable", "phg", "via"]
 
-    try:
-        for key in fieldNumKeys:
-            if key in jsonData:
-                fields.append("{0}={1}".format(key, jsonData.get(key)))
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
-        if "comment" in jsonData:
-            comment = parseTextString(jsonData.get("comment"), "comment")
-            if len(jsonData.get("comment")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        fields = parseTelemetry(jsonData, fields)
+    for key in fieldNumKeys:
+        if key in jsonData:
+            fields.append("{0}={1}".format(key, jsonData.get(key)))
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
+    if "comment" in jsonData:
+        comment = parseTextString(jsonData.get("comment"), "comment")
+        if len(jsonData.get("comment")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    fields = parseTelemetry(jsonData, fields)
 
-        fields = parseWeather(jsonData, fields)
+    fields = parseWeather(jsonData, fields)
 
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol" in jsonData:
-            comment = parseTextString(jsonData.get("symbol"), "symbol")
-            if len(jsonData.get("symbol")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract symbol from packet
-        if "symbol_table" in jsonData:
-            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
-            if len(jsonData.get("symbol_table")) > 0:
-                fields.append(comment)
-            else:
-                pass
-
-    except KeyError as e:
-        # Expect many KeyErrors for stations not sending telemetry
-        pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol" in jsonData:
+        comment = parseTextString(jsonData.get("symbol"), "symbol")
+        if len(jsonData.get("symbol")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract symbol from packet
+    if "symbol_table" in jsonData:
+        comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+        if len(jsonData.get("symbol_table")) > 0:
+            fields.append(comment)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 
@@ -674,48 +629,40 @@ def parseWX(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
-    except KeyError as e:
-        logger.error(e)
 
     tagStr = ",".join(tags)
 
     fieldTextKeys = ["to", "via"]
 
-    try:
-        fields = parseWeather(jsonData, fields)
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
-        if "comment" in jsonData:
-            comment = parseTextString(jsonData.get("comment"), "comment")
-            if len(jsonData.get("comment")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract wx_raw_timestamp from packet
-        if "wx_raw_timestamp" in jsonData:
-            rawtimestamp = parseTextString(jsonData.get("wx_raw_timestamp"), "wx_raw_timestamp")
-            if len(jsonData.get("wx_raw_timestamp")) > 0:
-                fields.append(rawtimestamp)
-            else:
-                pass
-
-    except KeyError as e:
-        # Expect many KeyErrors for stations not sending telemetry
-        pass
+    fields = parseWeather(jsonData, fields)
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
+    if "comment" in jsonData:
+        comment = parseTextString(jsonData.get("comment"), "comment")
+        if len(jsonData.get("comment")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract wx_raw_timestamp from packet
+    if "wx_raw_timestamp" in jsonData:
+        rawtimestamp = parseTextString(jsonData.get("wx_raw_timestamp"), "wx_raw_timestamp")
+        if len(jsonData.get("wx_raw_timestamp")) > 0:
+            fields.append(rawtimestamp)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 
@@ -746,40 +693,31 @@ def parseBeacon(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
     fieldTextKeys = ["to", "via"]
 
-    try:
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
-        if "text" in jsonData:
-            comment = parseTextString(jsonData.get("text"), "text")
-            if len(jsonData.get("text")) > 0:
-                fields.append(comment)
-            else:
-                pass
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-
-    except KeyError as e:
-        # Expect many KeyErrors for stations not sending telemetry
-        pass
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
+    if "text" in jsonData:
+        comment = parseTextString(jsonData.get("text"), "text")
+        if len(jsonData.get("text")) > 0:
+            fields.append(comment)
+        else:
+            pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 
@@ -812,50 +750,41 @@ def parseBulletin(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["bid"]
     fieldTextKeys = ["to", "via"]
 
-    try:
-        for key in fieldNumKeys:
-            if key in jsonData:
-                fields.append("{0}={1}".format(key, jsonData.get(key)))
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
-        if "message_text" in jsonData:
-            message = parseTextString(jsonData.get("message_text"), "message_text")
-            if len(jsonData.get("message_text")) > 0:
-                fields.append(message)
-            else:
-                pass
-        if "identifier" in jsonData:
-            identifier = parseTextString(jsonData.get("identifier"), "identifier")
-            if len(jsonData.get("identifier")) > 0:
-                fields.append(identifier)
-            else:
-                pass
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-
-    except KeyError as e:
-        # Expect many KeyErrors for stations not sending telemetry
-        pass
+    for key in fieldNumKeys:
+        if key in jsonData:
+            fields.append("{0}={1}".format(key, jsonData.get(key)))
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
+    if "message_text" in jsonData:
+        message = parseTextString(jsonData.get("message_text"), "message_text")
+        if len(jsonData.get("message_text")) > 0:
+            fields.append(message)
+        else:
+            pass
+    if "identifier" in jsonData:
+        identifier = parseTextString(jsonData.get("identifier"), "identifier")
+        if len(jsonData.get("identifier")) > 0:
+            fields.append(identifier)
+        else:
+            pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 
@@ -889,52 +818,43 @@ def parseMessage(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-    try:
-        tags.append("from={0}".format(jsonData.get("from")))
-        tags.append("format={0}".format(jsonData.get("format")))
-
-    except KeyError as e:
-        logger.error(e)
+    tags.append("from={0}".format(jsonData.get("from")))
+    tags.append("format={0}".format(jsonData.get("format")))
 
     tagStr = ",".join(tags)
 
     fieldNumKeys = ["msgNo"]
     fieldTextKeys = ["to", "via", "addresse"]
 
-    try:
-        for key in fieldNumKeys:
-            if key in jsonData:
-                fields.append("{0}={1}".format(key, jsonData.get(key)))
-        for key in fieldTextKeys:
-            if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
-        if "path" in jsonData:
-            fields.append(parsePath(jsonData.get("path")))
+    for key in fieldNumKeys:
+        if key in jsonData:
+            fields.append("{0}={1}".format(key, jsonData.get(key)))
+    for key in fieldTextKeys:
+        if key in jsonData:
+            fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+    if "path" in jsonData:
+        fields.append(parsePath(jsonData.get("path")))
 
-        if "message_text" in jsonData:
-            message = parseTextString(jsonData.get("message_text"), "message_text")
-            if len(jsonData.get("message_text")) > 0:
-                fields.append(message)
-            else:
-                pass
+    if "message_text" in jsonData:
+        message = parseTextString(jsonData.get("message_text"), "message_text")
+        if len(jsonData.get("message_text")) > 0:
+            fields.append(message)
+        else:
+            pass
 
-        if "response" in jsonData:
-            message = parseTextString(jsonData.get("response"), "response")
-            if len(jsonData.get("response")) > 0:
-                fields.append(message)
-            else:
-                pass
-        # Extract raw from packet
-        if "raw" in jsonData:
-            comment = parseTextString(jsonData.get("raw"), "raw")
-            if len(jsonData.get("raw")) > 0:
-                fields.append(comment)
-            else:
-                pass
-
-    except KeyError as e:
-        # Expect many KeyErrors for stations not sending telemetry
-        pass
+    if "response" in jsonData:
+        message = parseTextString(jsonData.get("response"), "response")
+        if len(jsonData.get("response")) > 0:
+            fields.append(message)
+        else:
+            pass
+    # Extract raw from packet
+    if "raw" in jsonData:
+        comment = parseTextString(jsonData.get("raw"), "raw")
+        if len(jsonData.get("raw")) > 0:
+            fields.append(comment)
+        else:
+            pass
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -308,38 +308,29 @@ def parseObject(jsonData):
 
     tagStr = ",".join(tags)
 
+    fieldNumKeys = ["latitude", "longitude", "posambiguity", "speed", "course", "timestamp"]
+    fieldTextKeys = ["alive", "via", "to", "raw_timestamp", "object_format", "object_name"]
+
     try:
-        fields.append("alive=\"{0}\"".format(jsonData.get("alive")))
-        if jsonData.get("via"):
-            fields.append("via=\"{0}\"".format(jsonData.get("via")))
-        fields.append("to=\"{0}\"".format(jsonData.get("to")))
-        fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
-        fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
-        fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity", 0)))
-        fields.append("speed={0}".format(jsonData.get("speed", 0)))
-        fields.append("course={0}".format(jsonData.get("course", 0)))
-        fields.append("rawTimestamp=\"{0}\"".format(jsonData.get("raw_timestamp", 0)))
-        fields.append("timestamp={0}".format(jsonData.get("timestamp", 0)))
-        fields.append("objectFormat=\"{0}\"".format(jsonData.get("object_format")))
-        fields.append("objectName=\"{0}\"".format(jsonData.get("object_name")))
-        if jsonData.get("path"):
+        for key in fieldNumKeys:
+            if key in jsonData:
+                fields.append("{0}={1}".format(key,jsonData.get(key)))
+        for key in fieldTextKeys:
+            if key in jsonData:
+                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+        if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
-
-    except KeyError as e:
-        logger.error("KeyError: {0}, Object Packet".format(e))
-        logger.error(jsonData)
-
-    try:
         if "comment" in jsonData:
             comment = parseTextString(jsonData.get("comment"), "comment")
             if len(jsonData.get("comment")) > 0:
                 fields.append(comment)
             else:
                 pass
+        fields = parseTelemetry(jsonData, fields)
 
-    except KeyError:
-        # Comment fields often are not present so just pass
-        pass
+    except KeyError as e:
+        logger.error("KeyError: {0}, object Packet".format(e))
+        logger.error(jsonData)
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -81,6 +81,16 @@ def jsonToLineProtocol(jsonData):
     # Uncomment for all other formats not yes parsed
     #logger.warning(jsonData["format"])
 
+def parseTelemetry(jsonData, fieldList):
+    if "telemetry" in jsonData:
+        items = jsonData.get("telemetry")
+        if "bits" in items:
+            fieldList.append("bits={0}".format(items.get("bits")))
+        if "vals" in items:
+            values = items.get("vals")
+            for analog in range(5):
+                fieldList.append("analog{0}={1}".format(analog + 1,values[analog]))
+    return fieldList
 
 def parseUncompressed(jsonData):
     """Parse uncompressed APRS packets into influxedb line protocol
@@ -162,14 +172,7 @@ def parseUncompressed(jsonData):
             fields.append(parsePath(jsonData.get("path")))
         if "comment" in jsonData:
             fields.append(parseTextString(jsonData.get("comment"), "comment"))
-        if "telemetry" in jsonData:
-            items = jsonData.get("telemetry")
-            if "bits" in items:
-                fields.append("bits={0}".format(items.get("bits")))
-            if "vals" in items:
-                values = items.get("vals")
-                for analog in range(5):
-                    fields.append("analog{0}={1}".format(analog + 1,values[analog]))
+        fields = parseTelemetry(jsonData, fields)
 
     except KeyError as e:
         logger.error(e)

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -85,7 +85,7 @@ def jsonToLineProtocol(jsonData):
 def parseTelemetry(jsonData, fieldList):
     '''parse telemetry from packets
 
-    Iterates through a telemetry formated packet to extra sequence, bits, and
+    Iterates through a packet to extra telemetry data: sequence, bits, and
     values. These are placed into the fieldList which is returned at the end of
     the function.
 
@@ -114,12 +114,27 @@ def parseTelemetry(jsonData, fieldList):
 
 
 def parseWeather(jsonData, fieldList):
-    wxFields = ["humidity", "pressure", "rain_1h", "rain_24h", "rain_since_midnight", "temperature", "wind_direction", "wind_gust", "wind_speed"]
+    '''parse weather data from packets
+
+    Iterates through a packet to extra weather data. Items which are found are
+    appended to the fieldList which is returned.
+
+    keyword arguments:
+    jsonData -- JSON packet from aprslib
+    fieldList -- list of field items currently parsed
+    '''
+
+    # Check for weather data key
     if "weather" in jsonData:
         items = jsonData.get("weather")
+
+        # Define weather items to check for
+        wxFields = ["humidity", "pressure", "rain_1h", "rain_24h", "rain_since_midnight", "temperature", "wind_direction", "wind_gust", "wind_speed"]
         for key in wxFields:
             if key in items:
                 fieldList.append("{0}={1}".format(key, items.get(key)))
+
+    # Return fieldList with found items appended
     return fieldList
 
 
@@ -173,69 +188,65 @@ def parseUncompressed(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
     # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course"]
     fieldTextKeys = ["to", "messagecapable", "phg", "rng", "via"]
 
-    # Extract fields from packet
+    # Extract number fields from packet
     for key in fieldNumKeys:
         if key in jsonData:
             fields.append("{0}={1}".format(key, jsonData.get(key)))
 
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
 
-    # Extract path and create string from list
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
 
-    # Extract comment from packet
+    # Extract comment
     if "comment" in jsonData:
         comment = parseTextString(jsonData.get("comment"), "comment")
         if len(jsonData.get("comment")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract raw from packet
+
+    # Extract raw packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract APRS symbol
     if "symbol" in jsonData:
         comment = parseTextString(jsonData.get("symbol"), "symbol")
         if len(jsonData.get("symbol")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract APRS symbol table
     if "symbol_table" in jsonData:
         comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
         if len(jsonData.get("symbol_table")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract raw_timestamp from packet
+
+    # Extract raw timestamp from packet
     if "raw_timestamp" in jsonData:
         rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
         if len(jsonData.get("raw_timestamp")) > 0:
             fields.append(rawtimestamp)
-        else:
-            pass
 
-
-    # Parse telemetry data if present
+    # Parse telemetry data
     fields = parseTelemetry(jsonData, fields)
 
-    # Parse weather data if present
+    # Parse weather data
     fields = parseWeather(jsonData, fields)
 
     # Combine all fields into a valid line protocol string

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -442,43 +442,29 @@ def parseCompressed(jsonData):
 
     tagStr = ",".join(tags)
 
+    fieldNumKeys = ["latitude","longitude","gpsfixstatus","altitude"]
+    fieldTextKeys = ["to", "messagecapable"]
+    fieldTelemetryKeys = ["seq","bits"]
+
     try:
-        #fields.append("messageCapable=\"{0}\"".format(jsonData.get("messagecapable")))
-        fields.append("to=\"{0}\"".format(jsonData.get("to")))
-        fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
-        fields.append("longitude={0}".format(jsonData.get("longitude", 0)))
-        fields.append("altitude={0}".format(jsonData.get("altitude", 0)))
-        fields.append("gpsFixStatus={0}".format(jsonData.get("gpsfixstatus", 0)))
-        if jsonData.get("path"):
+        for key in fieldNumKeys:
+            if key in jsonData:
+                fields.append("{0}={1}".format(key,jsonData.get(key)))
+        for key in fieldTextKeys:
+            if key in jsonData:
+                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+        if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
-
-    except KeyError as e:
-        logger.error(e)
-
-    try:
-        if jsonData["telemetry"]["seq"]:
-            fields.append("sequenceNumber={0}".format(jsonData["telemetry"]["seq"]))
-            fields.append("analog1={0}".format(jsonData["telemetry"]["vals"][0]))
-            fields.append("analog2={0}".format(jsonData["telemetry"]["vals"][1]))
-            fields.append("analog3={0}".format(jsonData["telemetry"]["vals"][2]))
-            fields.append("analog4={0}".format(jsonData["telemetry"]["vals"][3]))
-            fields.append("analog5={0}".format(jsonData["telemetry"]["vals"][4]))
-            fields.append("digital={0}".format(jsonData["telemetry"]["bits"]))
-
-    except KeyError as e:
-        # Expect many KeyErrors for stations not sending telemetry
-        pass
-
-    try:
         if "comment" in jsonData:
             comment = parseTextString(jsonData.get("comment"), "comment")
             if len(jsonData.get("comment")) > 0:
                 fields.append(comment)
             else:
                 pass
+        fields = parseTelemetry(jsonData, fields)
 
-    except KeyError:
-        # Comment fields often are not present so just pass
+    except KeyError as e:
+        # Expect many KeyErrors for stations not sending telemetry
         pass
 
     fieldsStr = ",".join(fields)

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -148,7 +148,7 @@ def parseUncompressed(jsonData):
     """
     # Converts aprslib JSON to influxdb line protocol
     # Schema
-    # tag = from
+    # field = from
     # field = to
     # field = symbol_table
     # field = symbol
@@ -191,7 +191,7 @@ def parseUncompressed(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -199,7 +199,7 @@ def parseUncompressed(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course"]
-    fieldTextKeys = ["to", "messagecapable", "phg", "rng", "via"]
+    fieldTextKeys = ["from", "to", "messagecapable", "phg", "rng", "via"]
 
     # Extract number fields from packet
     for key in fieldNumKeys:
@@ -296,7 +296,7 @@ def parseMicE(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -304,7 +304,7 @@ def parseMicE(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits"]
-    fieldTextKeys = ["via", "to", "mtype", "daodatumbyte"]
+    fieldTextKeys = ["from", "via", "to", "mtype", "daodatumbyte"]
 
     # Extract number fields from packet
     for key in fieldNumKeys:
@@ -399,7 +399,7 @@ def parseObject(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -407,7 +407,7 @@ def parseObject(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "speed", "course", "timestamp", "altitude"]
-    fieldTextKeys = ["alive", "via", "to", "object_format", "object_name", "rng", "daodatumbyte"]
+    fieldTextKeys = ["from", "alive", "via", "to", "object_format", "object_name", "rng", "daodatumbyte"]
 
     # Extract number fields from packet
     for key in fieldNumKeys:
@@ -489,7 +489,7 @@ def parseStatus(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -497,7 +497,7 @@ def parseStatus(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["timestamp"]
-    fieldTextKeys = ["via", "to"]
+    fieldTextKeys = ["from", "via", "to"]
 
     # Extract number fields from packet
     for key in fieldNumKeys:
@@ -591,7 +591,7 @@ def parseCompressed(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -599,7 +599,7 @@ def parseCompressed(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "gpsfixstatus", "altitude", "speed", "course", "timestamp"]
-    fieldTextKeys = ["to", "messagecapable", "phg", "via"]
+    fieldTextKeys = ["from", "to", "messagecapable", "phg", "via"]
 
     # Extract number fields from packet
     for key in fieldNumKeys:
@@ -686,14 +686,14 @@ def parseWX(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
     tagStr = ",".join(tags)
 
     # Create field key lists to iterate through
-    fieldTextKeys = ["to", "via"]
+    fieldTextKeys = ["from", "to", "via"]
 
     # Extract text fields from packet
     for key in fieldTextKeys:
@@ -756,14 +756,14 @@ def parseBeacon(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
     tagStr = ",".join(tags)
 
     # Create field key lists to iterate through
-    fieldTextKeys = ["to", "via"]
+    fieldTextKeys = ["from", "to", "via"]
 
     # Extract text fields from packet
     for key in fieldTextKeys:
@@ -819,7 +819,7 @@ def parseBulletin(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -827,7 +827,7 @@ def parseBulletin(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["bid"]
-    fieldTextKeys = ["to", "via"]
+    fieldTextKeys = ["from", "to", "via"]
 
     # Extract number fields from packet
     for key in fieldNumKeys:
@@ -895,7 +895,7 @@ def parseMessage(jsonData):
     measurement = "packet"
 
     # Obtain tags
-    tags.append("from={0}".format(jsonData.get("from")))
+    #tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
     # Join tags into comma separated string
@@ -903,7 +903,7 @@ def parseMessage(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["msgNo"]
-    fieldTextKeys = ["to", "via", "addresse"]
+    fieldTextKeys = ["from", "to", "via", "addresse"]
 
     # Extract number fields from packet
     for key in fieldNumKeys:

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -397,59 +397,65 @@ def parseObject(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
-    #tags.append("to={0}".format(jsonData.get("to")))
     tags.append("format={0}".format(jsonData.get("format")))
 
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldNumKeys = ["latitude", "longitude", "posambiguity", "speed", "course", "timestamp", "altitude"]
     fieldTextKeys = ["alive", "via", "to", "object_format", "object_name", "rng", "daodatumbyte"]
 
+    # Extract number fields from packet
     for key in fieldNumKeys:
         if key in jsonData:
             fields.append("{0}={1}".format(key, jsonData.get(key)))
+
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
+
+    # Extract comment
     if "comment" in jsonData:
         comment = parseTextString(jsonData.get("comment"), "comment")
         if len(jsonData.get("comment")) > 0:
             fields.append(comment)
-        else:
-            pass
+
+    # Parse telemetry
     fields = parseTelemetry(jsonData, fields)
-    # Extract raw from packet
+
+    # Extract raw packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract symbol
     if "symbol" in jsonData:
         comment = parseTextString(jsonData.get("symbol"), "symbol")
         if len(jsonData.get("symbol")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract symbol from packet
+
+    # Extract symbol table
     if "symbol_table" in jsonData:
         comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
         if len(jsonData.get("symbol_table")) > 0:
             fields.append(comment)
-        else:
-            pass
-    # Extract raw_timestamp from packet
+
+    # Extract raw_timestamp
     if "raw_timestamp" in jsonData:
         rawtimestamp = parseTextString(jsonData.get("raw_timestamp"), "raw_timestamp")
         if len(jsonData.get("raw_timestamp")) > 0:
             fields.append(rawtimestamp)
-        else:
-            pass
 
+    # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -442,7 +442,7 @@ def parseCompressed(jsonData):
     tagStr = ",".join(tags)
 
     try:
-        fields.append("messageCapable=\"{0}\"".format(jsonData.get("messagecapable")))
+        #fields.append("messageCapable=\"{0}\"".format(jsonData.get("messagecapable")))
         fields.append("to=\"{0}\"".format(jsonData.get("to")))
         fields.append("latitude={0}".format(jsonData.get("latitude", 0)))
         fields.append("longitude={0}".format(jsonData.get("longitude", 0)))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -38,21 +38,20 @@ def jsonToLineProtocol(jsonData):
     """
 
     try:
-        # Parse uncompressed format packets
         if jsonData["format"] == "uncompressed":
             # Parse uncompressed APRS packet
             return parseUncompressed(jsonData)
 
         if jsonData["format"] == "mic-e":
-            # Parse Mice-E APRS packet
+            # Parse mic-e APRS packet
             return parseMicE(jsonData)
 
         if jsonData["format"] == "object":
-            # Parse Object APRS packet
+            # Parse object APRS packet
             return parseObject(jsonData)
 
         if jsonData["format"] == "compressed":
-            # Parse Object APRS packet
+            # Parse compressed APRS packet
             return parseCompressed(jsonData)
 
         if jsonData["format"] == "status":
@@ -60,27 +59,27 @@ def jsonToLineProtocol(jsonData):
             return parseStatus(jsonData)
 
         if jsonData["format"] == "wx":
-            # Parse WX APRS packet
+            # Parse wx APRS packet
             return parseWX(jsonData)
 
         if jsonData["format"] == "beacon":
-            # Parse WX APRS packet
+            # Parse beacon APRS packet
             return parseBeacon(jsonData)
 
         if jsonData["format"] == "bulletin":
-            # Parse Bulletin APRS packet
+            # Parse bulletin APRS packet
             return parseBulletin(jsonData)
 
         if jsonData["format"] == "message":
-            # Parse Message APRS packet
+            # Parse message APRS packet
             return parseMessage(jsonData)
 
-        # Uncomment for all other formats not yes parsed
-        #logger.warning(jsonData["format"])
+        # All other formats not yes parsed
+        logger.debug("Not parsing {0} packets".format(jsonData))
 
     except StandardError:
         # An error occured
-        logger.error('A KeyError error occured', exc_info=True)
+        logger.error('A parsing StandardError occured', exc_info=True)
         logger.error("Packet: {0}".format(jsonData))
 
 def parseTelemetry(jsonData, fieldList):

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -149,16 +149,12 @@ def parseUncompressed(jsonData):
         pass
 
     try:
-        comment = jsonData.get("comment").encode('ascii', 'ignore')
+        if jsonData["comment"]:
+            fields.append(parseComment(jsonData["comment"]))
 
-        if comment:
-            fields.append("comment=\"{0}\"".format(comment.replace("\"", "")))
-
-    except UnicodeError as e:
-        logger.error(e)
-
-    except TypeError as e:
-        logger.error(e)
+    except KeyError as e:
+        logger.error("KeyError: {0}, Uncompressed Packet".format(e))
+        logger.error(jsonData)
 
     fieldsStr = ",".join(fields)
 
@@ -223,14 +219,7 @@ def parseMicE(jsonData):
 
     try:
         if jsonData["comment"]:
-            comment = jsonData.get("comment").encode('ascii', 'ignore')
-            fields.append("comment=\"{0}\"".format(comment.replace("\"", "")))
-
-    except UnicodeError as e:
-        logger.error(e)
-
-    except TypeError as e:
-        logger.error(e)
+            fields.append(parseComment(jsonData["comment"]))
 
     except KeyError as e:
         logger.error("KeyError: {0}, Mic-E Packet".format(e))
@@ -239,6 +228,19 @@ def parseMicE(jsonData):
     fieldsStr = ",".join(fields)
 
     return measurement + "," + tagStr + " " + fieldsStr
+
+def parseComment(rawComment):
+    try:
+        comment = rawComment.encode('ascii', 'ignore')
+        commentStr = ("comment=\"{0}\"".format(comment.replace("\"", "")))
+
+    except UnicodeError as e:
+        logger.error(e)
+
+    except TypeError as e:
+        logger.error(e)
+
+    return commentStr
 
 
 def callback(packet):

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -272,8 +272,8 @@ def parseMicE(jsonData):
 
     tagStr = ",".join(tags)
 
-    fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits", "daodatumbyte"]
-    fieldTextKeys = ["via", "to", "mtype"]
+    fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course", "mbits"]
+    fieldTextKeys = ["via", "to", "mtype", "daodatumbyte"]
 
     try:
         for key in fieldNumKeys:

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -169,19 +169,7 @@ def parseUncompressed(jsonData):
             if "vals" in items:
                 values = items.get("vals")
                 for analog in range(5):
-                    logger.warning("analog{0}={1}".format(analog + 1,values[analog]))
                     fields.append("analog{0}={1}".format(analog + 1,values[analog]))
-
-
-    # try:
-    #     fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    #     fields.append("latitude={0}".format(jsonData.get("latitude")))
-    #     fields.append("longitude={0}".format(jsonData.get("longitude")))
-    #     fields.append("posAmbiguity={0}".format(jsonData.get("posambiguity")))
-    #     fields.append("altitude={0}".format(jsonData.get("altitude")))
-    #     fields.append("speed={0}".format(jsonData.get("speed")))
-    #     if jsonData.get("path"):
-    #         fields.append(parsePath(jsonData.get("path")))
 
     except KeyError as e:
         logger.error(e)
@@ -192,31 +180,9 @@ def parseUncompressed(jsonData):
     except StandardError as e:
         logger.error(e)
 
-    # try:
-    #     if jsonData["telemetry"]["seq"]:
-    #         fields.append("sequenceNumber={0}".format(jsonData["telemetry"]["seq"]))
-    #         fields.append("analog1={0}".format(jsonData["telemetry"]["vals"][0]))
-    #         fields.append("analog2={0}".format(jsonData["telemetry"]["vals"][1]))
-    #         fields.append("analog3={0}".format(jsonData["telemetry"]["vals"][2]))
-    #         fields.append("analog4={0}".format(jsonData["telemetry"]["vals"][3]))
-    #         fields.append("analog5={0}".format(jsonData["telemetry"]["vals"][4]))
-    #         fields.append("digital={0}".format(jsonData["telemetry"]["bits"]))
-
-    # except KeyError as e:
-    #     # Expect many KeyErrors for stations not sending telemetry
-    #     pass
-
-    # try:
-    #     if jsonData["comment"]:
-    #         fields.append(parseTextString(jsonData["comment"], "comment"))
-
-    # except KeyError:
-    #     # Comment fields often are not present so just pass
-    #     pass
-
     fieldsStr = ",".join(fields)
 
-    #logger.warning(measurement + "," + tagStr + " " + fieldsStr)
+    logger.warning(measurement + "," + tagStr + " " + fieldsStr)
     return measurement + "," + tagStr + " " + fieldsStr
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -684,40 +684,45 @@ def parseWX(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
+    # Obtain tags
     tags.append("from={0}".format(jsonData.get("from")))
     tags.append("format={0}".format(jsonData.get("format")))
 
-
+    # Join tags into comma separated string
     tagStr = ",".join(tags)
 
+    # Create field key lists to iterate through
     fieldTextKeys = ["to", "via"]
 
-    fields = parseWeather(jsonData, fields)
+    # Extract text fields from packet
     for key in fieldTextKeys:
         if key in jsonData:
             fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
+
+    # Extract path
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
+
+    # Extract comment
     if "comment" in jsonData:
         comment = parseTextString(jsonData.get("comment"), "comment")
         if len(jsonData.get("comment")) > 0:
             fields.append(comment)
-        else:
-            pass
+
     # Extract raw from packet
     if "raw" in jsonData:
         comment = parseTextString(jsonData.get("raw"), "raw")
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
-        else:
-            pass
+
     # Extract wx_raw_timestamp from packet
     if "wx_raw_timestamp" in jsonData:
         rawtimestamp = parseTextString(jsonData.get("wx_raw_timestamp"), "wx_raw_timestamp")
         if len(jsonData.get("wx_raw_timestamp")) > 0:
             fields.append(rawtimestamp)
-        else:
-            pass
+
+    # Obtain weather data
+    fields = parseWeather(jsonData, fields)
 
     fieldsStr = ",".join(fields)
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -410,6 +410,21 @@ def parseObject(jsonData):
                 fields.append(comment)
             else:
                 pass
+        # Extract symbol from packet
+        if "symbol" in jsonData:
+            comment = parseTextString(jsonData.get("symbol"), "symbol")
+            if len(jsonData.get("symbol")) > 0:
+                fields.append(comment)
+            else:
+                pass
+        # Extract symbol from packet
+        if "symbol_table" in jsonData:
+            comment = parseTextString(jsonData.get("symbol_table"), "symbol_table")
+            if len(jsonData.get("symbol_table")) > 0:
+                fields.append(comment)
+            else:
+                pass
+
 
     except KeyError as e:
         logger.error("KeyError: {0}, object Packet".format(e))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -81,6 +81,7 @@ def jsonToLineProtocol(jsonData):
     # Uncomment for all other formats not yes parsed
     #logger.warning(jsonData["format"])
 
+
 def parseTelemetry(jsonData, fieldList):
     if "telemetry" in jsonData:
         items = jsonData.get("telemetry")
@@ -91,17 +92,19 @@ def parseTelemetry(jsonData, fieldList):
         if "vals" in items:
             values = items.get("vals")
             for analog in range(5):
-                fieldList.append("analog{0}={1}".format(analog + 1,values[analog]))
+                fieldList.append("analog{0}={1}".format(analog + 1, values[analog]))
     return fieldList
 
+
 def parseWeather(jsonData, fieldList):
-    wxFields = ["humidity","pressure","rain_1h","rain_24h","rain_since_midnight","temperature","wind_direction","wind_gust", "wind_speed"]
+    wxFields = ["humidity", "pressure", "rain_1h", "rain_24h", "rain_since_midnight", "temperature", "wind_direction", "wind_gust", "wind_speed"]
     if "weather" in jsonData:
         items = jsonData.get("weather")
         for key in wxFields:
             if key in items:
-                fieldList.append("{0}={1}".format(key,items.get(key)))
+                fieldList.append("{0}={1}".format(key, items.get(key)))
     return fieldList
+
 
 def parseUncompressed(jsonData):
     """Parse uncompressed APRS packets into influxedb line protocol
@@ -153,7 +156,6 @@ def parseUncompressed(jsonData):
     # Set measurement to "packet"
     measurement = "packet"
 
-
     try:
         tags.append("from={0}".format(jsonData.get("from")))
         tags.append("format={0}".format(jsonData.get("format")))
@@ -164,19 +166,18 @@ def parseUncompressed(jsonData):
     tagStr = ",".join(tags)
 
     # Create field key lists to iterate through
-    fieldNumKeys = ["latitude","longitude","posambiguity","altitude","speed", "course"]
+    fieldNumKeys = ["latitude", "longitude", "posambiguity", "altitude", "speed", "course"]
     fieldTextKeys = ["to", "messagecapable", "phg", "rng", "raw_timestamp", "via"]
-    fieldTelemetryKeys = ["seq","bits"]
 
     # Extract fields from packet
     try:
         for key in fieldNumKeys:
             if key in jsonData:
-                fields.append("{0}={1}".format(key,jsonData.get(key)))
+                fields.append("{0}={1}".format(key, jsonData.get(key)))
 
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
 
         # Extract path and create string from list
         if "path" in jsonData:
@@ -262,7 +263,6 @@ def parseMicE(jsonData):
     # field = daodatumbyte
     # field = path
 
-
     # initialize variables
     tags = []
     fields = []
@@ -285,10 +285,10 @@ def parseMicE(jsonData):
     try:
         for key in fieldNumKeys:
             if key in jsonData:
-                fields.append("{0}={1}".format(key,jsonData.get(key)))
+                fields.append("{0}={1}".format(key, jsonData.get(key)))
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         if "comment" in jsonData:
@@ -390,10 +390,10 @@ def parseObject(jsonData):
     try:
         for key in fieldNumKeys:
             if key in jsonData:
-                fields.append("{0}={1}".format(key,jsonData.get(key)))
+                fields.append("{0}={1}".format(key, jsonData.get(key)))
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         if "comment" in jsonData:
@@ -424,7 +424,6 @@ def parseObject(jsonData):
                 fields.append(comment)
             else:
                 pass
-
 
     except KeyError as e:
         logger.error("KeyError: {0}, object Packet".format(e))
@@ -476,10 +475,10 @@ def parseStatus(jsonData):
     try:
         for key in fieldNumKeys:
             if key in jsonData:
-                fields.append("{0}={1}".format(key,jsonData.get(key)))
+                fields.append("{0}={1}".format(key, jsonData.get(key)))
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         fields = parseTelemetry(jsonData, fields)
@@ -566,17 +565,16 @@ def parseCompressed(jsonData):
 
     tagStr = ",".join(tags)
 
-    fieldNumKeys = ["latitude","longitude","gpsfixstatus","altitude", "speed", "course", "timestamp"]
+    fieldNumKeys = ["latitude", "longitude", "gpsfixstatus", "altitude", "speed", "course", "timestamp"]
     fieldTextKeys = ["to", "messagecapable", "phg", "via"]
-    fieldTelemetryKeys = ["seq","bits"]
 
     try:
         for key in fieldNumKeys:
             if key in jsonData:
-                fields.append("{0}={1}".format(key,jsonData.get(key)))
+                fields.append("{0}={1}".format(key, jsonData.get(key)))
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         if "comment" in jsonData:
@@ -669,7 +667,7 @@ def parseWX(jsonData):
         fields = parseWeather(jsonData, fields)
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         if "comment" in jsonData:
@@ -712,7 +710,6 @@ def parseBeacon(jsonData):
     # field = path
     # field = raw
 
-
     # initialize variables
     tags = []
     fields = []
@@ -729,13 +726,12 @@ def parseBeacon(jsonData):
 
     tagStr = ",".join(tags)
 
-
     fieldTextKeys = ["to", "via"]
 
     try:
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         if "text" in jsonData:
@@ -802,10 +798,10 @@ def parseBulletin(jsonData):
     try:
         for key in fieldNumKeys:
             if key in jsonData:
-                fields.append("{0}={1}".format(key,jsonData.get(key)))
+                fields.append("{0}={1}".format(key, jsonData.get(key)))
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
         if "message_text" in jsonData:
@@ -879,10 +875,10 @@ def parseMessage(jsonData):
     try:
         for key in fieldNumKeys:
             if key in jsonData:
-                fields.append("{0}={1}".format(key,jsonData.get(key)))
+                fields.append("{0}={1}".format(key, jsonData.get(key)))
         for key in fieldTextKeys:
             if key in jsonData:
-                fields.append("{0}=\"{1}\"".format(key,jsonData.get(key)))
+                fields.append("{0}=\"{1}\"".format(key, jsonData.get(key)))
         if "path" in jsonData:
             fields.append(parsePath(jsonData.get("path")))
 
@@ -981,7 +977,6 @@ def callback(packet):
         except influxdb.exceptions.InfluxDBServerError as e:
             logger.error(packet["raw"])
             logger.error(e)
-
 
 
 def connectInfluxDB():

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -781,6 +781,10 @@ def callback(packet):
             logger.error(e)
             logger.error(packet)
 
+        except influxdb.exceptions.InfluxDBServerError as e:
+            logger.error(e)
+            logger.error(packet)
+
 
 def connectInfluxDB():
     """Connect to influxdb database with configuration values"""

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -173,7 +173,6 @@ def parseUncompressed(jsonData):
         if "comment" in jsonData:
             comment = parseTextString(jsonData.get("comment"), "comment")
             if len(jsonData.get("comment")) > 0:
-                pass
                 fields.append(comment)
             else:
                 pass
@@ -254,8 +253,12 @@ def parseMicE(jsonData):
         logger.error(jsonData)
 
     try:
-        if jsonData["comment"]:
-            fields.append(parseTextString(jsonData["comment"], "comment"))
+        if "comment" in jsonData:
+            comment = parseTextString(jsonData.get("comment"), "comment")
+            if len(jsonData.get("comment")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -340,8 +343,12 @@ def parseObject(jsonData):
         logger.error(jsonData)
 
     try:
-        if jsonData["comment"]:
-            fields.append(parseTextString(jsonData["comment"], "comment"))
+        if "comment" in jsonData:
+            comment = parseTextString(jsonData.get("comment"), "comment")
+            if len(jsonData.get("comment")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -388,7 +395,11 @@ def parseStatus(jsonData):
     if jsonData.get("via"):
         fields.append("via=\"{0}\"".format(jsonData.get("via")))
     fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    fields.append(parseTextString(jsonData["status"], "status"))
+    status = parseTextString(jsonData["status"], "status")
+    if len(jsonData.get("status")) > 0:
+        fields.append(status)
+    else:
+        pass
 
     if jsonData.get("path"):
         fields.append(parsePath(jsonData.get("path")))
@@ -473,8 +484,12 @@ def parseCompressed(jsonData):
         pass
 
     try:
-        if jsonData["comment"]:
-            fields.append(parseTextString(jsonData["comment"], "comment"))
+        if "comment" in jsonData:
+            comment = parseTextString(jsonData.get("comment"), "comment")
+            if len(jsonData.get("comment")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -550,8 +565,12 @@ def parseWX(jsonData):
         logger.error(jsonData)
 
     try:
-        if jsonData["comment"]:
-            fields.append(parseTextString(jsonData["comment"], "comment"))
+        if "comment" in jsonData:
+            comment = parseTextString(jsonData.get("comment"), "comment")
+            if len(jsonData.get("comment")) > 0:
+                fields.append(comment)
+            else:
+                pass
 
     except KeyError:
         # Comment fields often are not present so just pass
@@ -598,7 +617,12 @@ def parseBeacon(jsonData):
     if jsonData.get("via"):
         fields.append("via=\"{0}\"".format(jsonData.get("via")))
     fields.append("to=\"{0}\"".format(jsonData.get("to")))
-    fields.append(parseTextString(jsonData["text"], "text"))
+
+    text = parseTextString(jsonData["text"], "text")
+    if len(jsonData.get("text")) > 0:
+        fields.append(text)
+    else:
+        pass
 
     if jsonData.get("path"):
         fields.append(parsePath(jsonData.get("path")))
@@ -644,8 +668,11 @@ def parseBulletin(jsonData):
     tagStr = ",".join(tags)
 
     try:
-        if jsonData["message_text"]:
-            fields.append(parseTextString(jsonData["message_text"], "messageText"))
+        text = parseTextString(jsonData["message_text"], "messageText")
+        if len(jsonData.get("message_text")) > 0:
+            fields.append(text)
+        else:
+            pass
 
     except KeyError:
         # happens
@@ -702,8 +729,11 @@ def parseMessage(jsonData):
     tagStr = ",".join(tags)
 
     try:
-        if jsonData["message_text"]:
-            fields.append(parseTextString(jsonData["message_text"], "messageText"))
+        text = parseTextString(jsonData["message_text"], "messageText")
+        if len(jsonData.get("message_text")) > 0:
+            fields.append(text)
+        else:
+            pass
 
     except KeyError:
         # happens
@@ -728,6 +758,7 @@ def parseTextString(rawText, name):
     if len(rawText) > 0:
         try:
             text = rawText.encode('ascii', 'replace')
+            text = text.replace("\\", "\\\\")
             text = text.replace("\'", "\\\'")
             text = text.replace("\"", "\\\"")
             textStr = ("{0}=\"{1}\"".format(name, text))

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -78,7 +78,8 @@ def jsonToLineProtocol(jsonData):
         # Parse Message APRS packet
         return parseMessage(jsonData)
 
-    logger.warning(jsonData["format"])
+    # Uncomment for all other formats not yes parsed
+    #logger.warning(jsonData["format"])
 
 
 def parseUncompressed(jsonData):

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -139,7 +139,8 @@ def parseWeather(jsonData, fieldList):
 
 
 def parseUncompressed(jsonData):
-    """Parse uncompressed APRS packets into influxedb line protocol
+    """Parse uncompressed APRS packets into influxedb line protocol. Returns a
+    valid line protocol string.
 
     keyword arguments:
     jsonData -- aprslib parsed JSON packet
@@ -257,7 +258,7 @@ def parseUncompressed(jsonData):
 
 
 def parseMicE(jsonData):
-    """Parse Mic-e APRS packets into influxedb line protocol
+    """Parse mic-e APRS packets into influxedb line protocol
 
     keyword arguments:
     jsonData -- aprslib parsed JSON packet

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -116,7 +116,7 @@ def parseUncompressed(jsonData):
     # field = symbol_table* (SKIPPED)
     # field = symbol* (SKIPPED)
     # tag = format
-    # field = via*
+    # field = via
     # field = messagecapable
     # field = latitude
     # field = longitude
@@ -125,26 +125,26 @@ def parseUncompressed(jsonData):
     # field = raw*
     # field = speed
     # field = course
-    # field = raw_timestamp*
+    # field = raw_timestamp
     # field = seq
-    # field = analog1*
-    # field = analog2*
-    # field = analog3*
-    # field = analog4*
-    # field = analog5*
+    # field = analog1
+    # field = analog2
+    # field = analog3
+    # field = analog4
+    # field = analog5
     # field = bits
     # field = phg
     # field = rng
     # field = comment
     # field = path
-    # field = pressure*
-    # field = rain_1h*
-    # field = rain_24h*
-    # field = rain_since_midnight*
-    # field = temperature*
-    # field = wind_direction*
-    # field = wind_gust*
-    # field = wind_speed*
+    # field = pressure
+    # field = rain_1h
+    # field = rain_24h
+    # field = rain_since_midnight
+    # field = temperature
+    # field = wind_direction
+    # field = wind_gust
+    # field = wind_speed
 
     # initialize variables
     tags = []
@@ -152,6 +152,7 @@ def parseUncompressed(jsonData):
 
     # Set measurement to "packet"
     measurement = "packet"
+
 
     try:
         tags.append("from={0}".format(jsonData.get("from")))
@@ -164,7 +165,7 @@ def parseUncompressed(jsonData):
 
     # Create field key lists to iterate through
     fieldNumKeys = ["latitude","longitude","posambiguity","altitude","speed", "course"]
-    fieldTextKeys = ["to", "messagecapable", "phg", "rng"]
+    fieldTextKeys = ["to", "messagecapable", "phg", "rng", "raw_timestamp", "via"]
     fieldTelemetryKeys = ["seq","bits"]
 
     # Extract fields from packet

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ pytz>=2017.2
 requests>=2.18.4
 six>=1.11.0
 urllib3>=1.22
-flake8>=3.4.1
+pytest>=3.0.7
+pytest-flake8>=0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytz>=2017.2
 requests>=2.18.4
 six>=1.11.0
 urllib3>=1.22
+flake8>=3.4.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='aprs2influxdb',
-    version='0.1.1',
+    version='0.2.0',
     author='Bryce Salmi',
     author_email='Bryce@FaradayRF.com',
     packages=['aprs2influxdb'],


### PR DESCRIPTION
Pulls in the following changes that support parsing almost all types of packets.

 #9 by parsing all known aprslib packets except for `telemetry-format` as that is simply channel naming and scaling which will be another PR
- Parsing of `uncompressed` APRS-IS packets
- Parsing of `mic-e` APRS-IS packets
- Parsing of `object` APRS-IS packets
- Parsing of `compressed` APRS-IS packets
- Parsing of `status` APRS-IS packets
- Parsing of `wx` APRS-IS packets
- Parsing of `beacon` APRS-IS packets
- Parsing of `bulletin` APRS-IS packets
- Parsing of `message` APRS-IS packets
- Updated exception handling to be compartmentallized and informative with the `exc_info=True` functionality
- Brought out telemetry parsing into separate function `parseTelemetry(jsonFata, fieldList)`
- Brought out telemetry parsing into separate function `parseWeather(jsonFata, fieldList)`
- Text parsing for comments and similar are a separate function `parseTextString(rawText, name)`
- paths are automatically converted into a comma-separated string with `parsePath`
- Fixes #20 since the "to" tag is no longer a tag and is now a field
- Fixes #18 since proper sanitation of text/comments occurs without error
- Fixes #8 as proper sanitation occurs now. No errors observed in over 24 hours of a test run.
- Adds Travis CI build support for pytest checks, based on `faraday-software` configuration
- Adds Travis CI build badge to `README.md`
- Updated `README.md` with supported APRS packets