### PR TITLE
Support APRS Telemetry-Message Equation Parsing & Scaling

### DIFF
--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -113,7 +113,7 @@ def parseTelemetry(jsonData, fieldList):
         # Attempt to retrieve scaling values from telemetryDictionary
         try:
             channels = telemetryDictionary[jsonData["from"]]
-        except KeyError as e:
+        except KeyError:
             # No scaling values found, assign generic scaling to channels
             channels = []
             for eqn in range(5):
@@ -129,7 +129,7 @@ def parseTelemetry(jsonData, fieldList):
             values = items.get("vals")
             for analog in range(5):
                 # Apply scaling equation A*V**2 + B*V + C
-                telemVal = channels[analog]["a"]*math.pow(values[analog],2) + channels[analog]["b"]*values[analog] + channels[analog]["c"]
+                telemVal = channels[analog]["a"] * math.pow(values[analog], 2) + channels[analog]["b"] * values[analog] + channels[analog]["c"]
                 fieldList.append("analog{0}={1}".format(analog + 1, telemVal))
 
     # Return fieldList with found items appended

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -121,24 +121,19 @@ def parseTelemetry(jsonData, fieldList):
 
 def parseParameters(jsonData, fieldList):
     if("tPARM" in jsonData):
-        # Should probably just iterate through list of strings and append as I go, like fieldList
+        fieldList.append("{0}=\"{1}\"".format("type", "PARM"))
+
         items = jsonData.get("tPARM")
-        logger.warn(len(items))
-        logger.warn(items)
-        analog1 = items[0]
-        analog2 = items[1]
-        analog3 = items[2]
-        analog4 = items[3]
-        analog5 = items[4]
-        b1 = items[5]
-        b2 = items[6]
-        b3 = items[7]
-        b4 = items[8]
-        b5 = items[9]
-        b6 = items[10]
-        b7 = items[11]
-        b8 = items[12]
-        logger.warn(b8)
+        #logger.warn(items)
+        telemetryList = ["analog1", "analog2", "analog3", "analog4", "analog5", "digital1", "digital2", "digital3", "digital4", "digital5", "digital6", "digital7", "digital8"]
+        for parameter in telemetryList:
+            if(len(items[0]) <= 0):
+                fieldList.append("{0}=\"{1}\"".format(parameter, "RAW"))
+            else:
+                fieldList.append("{0}=\"{1}\"".format(parameter, items.pop(0)))
+
+        # Return fieldList with found items appended
+        return fieldList
 
 
 def parseWeather(jsonData, fieldList):
@@ -1028,7 +1023,8 @@ def parseTelemetryMessage(jsonData):
     # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
-    #logger.warn(measurement + "," + tagStr + " " + fieldsStr)
+    if jsonData["from"] == "KB1LQC-1":
+        logger.warn(measurement + "," + tagStr + " " + fieldsStr)
     return measurement + "," + tagStr + " " + fieldsStr
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -119,6 +119,28 @@ def parseTelemetry(jsonData, fieldList):
     return fieldList
 
 
+def parseParameters(jsonData, fieldList):
+    if("tPARM" in jsonData):
+        # Should probably just iterate through list of strings and append as I go, like fieldList
+        items = jsonData.get("tPARM")
+        logger.warn(len(items))
+        logger.warn(items)
+        analog1 = items[0]
+        analog2 = items[1]
+        analog3 = items[2]
+        analog4 = items[3]
+        analog5 = items[4]
+        b1 = items[5]
+        b2 = items[6]
+        b3 = items[7]
+        b4 = items[8]
+        b5 = items[9]
+        b6 = items[10]
+        b7 = items[11]
+        b8 = items[12]
+        logger.warn(b8)
+
+
 def parseWeather(jsonData, fieldList):
     '''parse weather data from packets
 
@@ -1001,10 +1023,12 @@ def parseTelemetryMessage(jsonData):
         if len(jsonData.get("raw")) > 0:
             fields.append(comment)
 
+    parseParameters(jsonData, fields)
+
     # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
-    logger.warn(measurement + "," + tagStr + " " + fieldsStr)
+    #logger.warn(measurement + "," + tagStr + " " + fieldsStr)
     return measurement + "," + tagStr + " " + fieldsStr
 
 

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 import os
+import math
 
 from logging.handlers import TimedRotatingFileHandler
 
@@ -109,11 +110,31 @@ def parseTelemetry(jsonData, fieldList):
         # Extract IO bits
         if "bits" in items:
             fieldList.append("bits={0}".format(items.get("bits")))
-        # Extra analog values
+
+        # test
+        #logger.warn(telemetryDictionary.get(jsonData["from"]))
+        try:
+            channels = telemetryDictionary[jsonData["from"]]
+            #logger.warn(channels)
+        except KeyError as e:
+            # No scaling values
+            channels = []
+            for eqn in range(5):
+                equations = {"a": 0, "b": 0, "c": 0, }
+                equations["a"] = 0
+                equations["b"] = 1
+                equations["c"] = 0
+                channels.append(equations)
+
+        # Extract analog values
         if "vals" in items:
             values = items.get("vals")
             for analog in range(5):
-                fieldList.append("analog{0}={1}".format(analog + 1, values[analog]))
+                # AxV**2 + B*V + C
+                telemVal = channels[analog]["a"]*math.pow(values[analog],2) + channels[analog]["b"]*values[analog] + channels[analog]["c"]
+                #logger.warn("analog{0}={1}".format(analog + 1, telemVal))
+                fieldList.append("analog{0}={1}".format(analog + 1, telemVal))
+
 
     # Return fieldList with found items appended
     return fieldList

--- a/aprs2influxdb/__main__.py
+++ b/aprs2influxdb/__main__.py
@@ -76,8 +76,8 @@ def jsonToLineProtocol(jsonData):
 
         if jsonData["format"] == "telemetry-message":
             # Parse telemetry-message APRS packet
-            logger.warn(jsonData)
-            #return parseMessage(jsonData)
+            #logger.warn(jsonData)
+            return parseTelemetryMessage(jsonData)
 
         # All other formats not yes parsed
         logger.debug("Not parsing {0} packets".format(jsonData))
@@ -956,8 +956,8 @@ def parseTelemetryMessage(jsonData):
     tags = []
     fields = []
 
-    # Set measurement to "packet"
-    measurement = "packet"
+    # Set measurement to "configs"
+    measurement = "configs"
 
     # Obtain tags
     tags.append("format={0}".format(jsonData.get("format")))
@@ -983,17 +983,17 @@ def parseTelemetryMessage(jsonData):
     if "path" in jsonData:
         fields.append(parsePath(jsonData.get("path")))
 
-    # Extract message text
-    if "message_text" in jsonData:
-        message = parseTextString(jsonData.get("message_text"), "message_text")
-        if len(jsonData.get("message_text")) > 0:
-            fields.append(message)
+    # # Extract message text
+    # if "message_text" in jsonData:
+    #     message = parseTextString(jsonData.get("message_text"), "message_text")
+    #     if len(jsonData.get("message_text")) > 0:
+    #         fields.append(message)
 
-    # Extract response
-    if "response" in jsonData:
-        message = parseTextString(jsonData.get("response"), "response")
-        if len(jsonData.get("response")) > 0:
-            fields.append(message)
+    # # Extract response
+    # if "response" in jsonData:
+    #     message = parseTextString(jsonData.get("response"), "response")
+    #     if len(jsonData.get("response")) > 0:
+    #         fields.append(message)
 
     # Extract raw from packet
     if "raw" in jsonData:
@@ -1004,6 +1004,7 @@ def parseTelemetryMessage(jsonData):
     # Combine final valid line protocol string
     fieldsStr = ",".join(fields)
 
+    logger.warn(measurement + "," + tagStr + " " + fieldsStr)
     return measurement + "," + tagStr + " " + fieldsStr
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='aprs2influxdb',
-    version='0.2.0',
+    version='0.2.1',
     author='Bryce Salmi',
     author_email='Bryce@FaradayRF.com',
     packages=['aprs2influxdb'],


### PR DESCRIPTION
This PR introduces a simplified version of `aprslib` 'telemetry-message' parsing. It currently only supports parsing of the "tEQNS" data from a telemetry-message. This is because Grafana cannot use a SELECT statements in a template when using influxdb. This is unfortunate and results in us not easily supporting automatic channel names/parameters/units assignments.

@kb1lqd  @el-iso  @reillyeon @jbemenheiser 

![image](https://user-images.githubusercontent.com/331540/32148847-635a58da-bcb9-11e7-9b63-68c56fa95466.png)

## Changes
* Parses a telemetry-message for 'tEQNS"
* Creates a global dictionary with each telemetry station being assigned scaling coefficients. This is in memory and does not persist between invocations of `aprs2influxdb`
* Changes telemetry parsing to search for station in telemetryDictionary and apply scaling coefficients prior to insertion into the database.
* Closes out the telemetry portion of #17 

Please remember that even when `aprs2influxdb` is started it will not apply scaling values (defaults to a=0, b=1, c=0) until the station transmits them. This means that it could be minutes to hours before new coefficients are applied depending on the station configuration.

